### PR TITLE
Fix HiDPI scaling handling

### DIFF
--- a/include/neowall.h
+++ b/include/neowall.h
@@ -108,8 +108,14 @@ struct output_state {
     struct compositor_surface *compositor_surface;  /* Compositor abstraction surface */
 
     uint32_t name;              /* Wayland output name/ID */
+    /* width/height represent the current physical buffer in pixels */
     int32_t width;
     int32_t height;
+    /* cached logical + mode sizes to handle HiDPI resizes */
+    int32_t logical_width;
+    int32_t logical_height;
+    int32_t pixel_width;
+    int32_t pixel_height;
     int32_t scale;
     int32_t transform;
 

--- a/src/output.c
+++ b/src/output.c
@@ -38,6 +38,12 @@ struct output_state *output_create(struct neowall_state *state,
     out->output = output;
     out->xdg_output = NULL;
     out->name = name;
+    out->width = 0;
+    out->height = 0;
+    out->logical_width = 0;
+    out->logical_height = 0;
+    out->pixel_width = 0;
+    out->pixel_height = 0;
     out->scale = 1;
     out->transform = WL_OUTPUT_TRANSFORM_NORMAL;
     out->configured = false;


### PR DESCRIPTION
## Summary
- Refactored HiDPI scaling to properly handle logical vs physical dimensions
- Added separate tracking for logical, pixel, and render buffer dimensions
- Fixed EGL window resizing to use physical buffer dimensions
- Improved scale factor handling with proper validation and normalization

## Changes
- Added `logical_width`, `logical_height`, `pixel_width`, `pixel_height` fields to `output_state`
- Implemented `output_apply_render_size()` to centralize dimension calculations
- Updated output event handlers (mode, scale, configure) to use new dimension tracking
- Ensures buffer scale is set before surface commits