### PR TITLE
Preserve shader clock across reloads

### DIFF
--- a/include/neowall.h
+++ b/include/neowall.h
@@ -156,6 +156,7 @@ struct output_state {
     GLuint glitch_program;              /* Shader program for glitch transition */
     GLuint pixelate_program;            /* Shader program for pixelate transition */
     GLuint live_shader_program;         /* Shader program for live wallpaper */
+    char current_shader_path[MAX_PATH_LENGTH];
     GLuint vbo;
 
     /* Cached uniform locations for performance */
@@ -194,7 +195,8 @@ struct output_state {
     uint64_t last_frame_time;
     uint64_t last_cycle_time;           /* Last time wallpaper was changed/cycled */
     uint64_t transition_start_time;
-    uint64_t shader_start_time;         /* Time when shader was loaded (for animation) */
+    uint64_t shader_start_time;         /* Time when shader clock last restarted */
+    uint64_t shader_time_accum_ms;      /* Accumulated time preserved across reloads */
     uint64_t shader_fade_start_time;    /* Time when shader fade started (for cross-fade) */
     char pending_shader_path[MAX_PATH_LENGTH]; /* Next shader to load after fade-out */
     float transition_progress;

--- a/src/config.c
+++ b/src/config.c
@@ -1931,6 +1931,12 @@ void config_reload(struct neowall_state *state) {
         memset(&output->gl_state, 0, sizeof(output->gl_state));
         
         /* Reset all timing and state */
+        if (output->shader_start_time > 0) {
+            uint64_t now = get_time_ms();
+            if (now >= output->shader_start_time) {
+                output->shader_time_accum_ms += now - output->shader_start_time;
+            }
+        }
         output->transition_start_time = 0;
         output->transition_progress = 0.0f;
         output->shader_start_time = 0;


### PR DESCRIPTION


https://github.com/user-attachments/assets/8bc03e13-4fc6-4ff4-9616-b9a2de328fae

## Summary
- Preserve shader animation time across configuration reloads
- Added time accumulator to maintain shader continuity
- Track current shader path to detect when same shader is reloaded

## Changes
- Added `shader_time_accum_ms` field to accumulate elapsed time across reloads
- Added `current_shader_path` to track loaded shader
- Updated `output_set_shader()` to preserve accumulated time for same shader
- Modified `render_frame_shader()` to include accumulated time in calculations
- Updated config reload to preserve shader clock state