### PR TITLE
fix: set default cursor when pointer enters wallpaper on wlroots compositors

### DIFF
--- a/include/compositor/backends/wayland.h
+++ b/include/compositor/backends/wayland.h
@@ -21,6 +21,7 @@
  */
 
 #include <wayland-client.h>
+#include <wayland-cursor.h>
 #include "xdg-output-unstable-v1-client-protocol.h"
 #include "tearing-control-v1-client-protocol.h"
 
@@ -44,6 +45,10 @@ typedef struct wayland {
     /* Back-pointer to main neowall state */
     struct neowall_state *state;
     
+    /* Cursor state for setting cursor on pointer enter */
+    struct wl_cursor_theme *cursor_theme;
+    struct wl_surface *cursor_surface;
+
     /* Initialization flag */
     bool initialized;
 } wayland_t;

--- a/meson.build
+++ b/meson.build
@@ -60,10 +60,11 @@ x11_backend_option = get_option('x11_backend')
 # Wayland dependencies
 wayland_client_dep = dependency('wayland-client', required: false)
 wayland_egl_dep = dependency('wayland-egl', required: false)
+wayland_cursor_dep = dependency('wayland-cursor', required: false)
 wayland_protocols_dep = dependency('wayland-protocols', required: false)
 
 # We use pre-generated protocol files, so only need client libs at runtime
-has_wayland_deps = wayland_client_dep.found() and wayland_egl_dep.found() and wayland_protocols_dep.found()
+has_wayland_deps = wayland_client_dep.found() and wayland_egl_dep.found() and wayland_cursor_dep.found() and wayland_protocols_dep.found()
 
 # Determine if Wayland backend should be enabled
 if wayland_backend_option.disabled()
@@ -303,7 +304,7 @@ deps = [
 ]
 
 if has_wayland
-  deps += [wayland_client_dep, wayland_egl_dep]
+  deps += [wayland_client_dep, wayland_egl_dep, wayland_cursor_dep]
 endif
 
 if has_x11

--- a/src/compositor/backends/wayland/compositors/wlr_layer_shell.c
+++ b/src/compositor/backends/wayland/compositors/wlr_layer_shell.c
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <errno.h>
 #include <wayland-client.h>
+#include <wayland-cursor.h>
 #include <wayland-egl.h>
 #include "compositor.h"
 #include "compositor/backends/wayland.h"
@@ -118,14 +119,35 @@ static void pointer_handle_enter(void *data, struct wl_pointer *pointer,
                                  uint32_t serial, struct wl_surface *surface,
                                  wl_fixed_t surface_x, wl_fixed_t surface_y) {
     (void)data;
-    (void)pointer;
-    (void)serial;
     (void)surface;
 
     double x = wl_fixed_to_double(surface_x);
     double y = wl_fixed_to_double(surface_y);
 
     log_debug("Wayland pointer entered surface at (%.2f, %.2f)", x, y);
+
+    /* Set the default arrow cursor when pointer enters the wallpaper surface */
+    wayland_t *wl = wayland_get();
+    if (!wl || !wl->cursor_theme || !wl->cursor_surface) {
+        return;
+    }
+
+    struct wl_cursor *cursor = wl_cursor_theme_get_cursor(wl->cursor_theme, "left_ptr");
+    if (!cursor || cursor->image_count == 0) {
+        return;
+    }
+
+    struct wl_cursor_image *image = cursor->images[0];
+    struct wl_buffer *buffer = wl_cursor_image_get_buffer(image);
+    if (!buffer) {
+        return;
+    }
+
+    wl_surface_attach(wl->cursor_surface, buffer, 0, 0);
+    wl_surface_damage(wl->cursor_surface, 0, 0, image->width, image->height);
+    wl_surface_commit(wl->cursor_surface);
+    wl_pointer_set_cursor(pointer, serial, wl->cursor_surface,
+                          image->hotspot_x, image->hotspot_y);
 }
 
 static void pointer_handle_leave(void *data, struct wl_pointer *pointer,

--- a/src/compositor/backends/wayland/wayland_core.c
+++ b/src/compositor/backends/wayland/wayland_core.c
@@ -527,6 +527,29 @@ bool wayland_init_registry(struct neowall_state *state) {
     /* Mark as initialized */
     wl->initialized = true;
 
+    /* Shared memory buffers not available */
+    if (!wl->shm) {
+        log_debug("Wayland shared memory buffers not available");
+        return false;
+    }
+
+    /* Initialize cursor theme and surface for pointer enter events */
+    wl->cursor_theme = wl_cursor_theme_load(NULL, 24, wl->shm);
+    if (!wl->cursor_theme) {
+        log_warn("Failed to load cursor theme");
+        /* This is an acceptable minor issue */
+        return true;
+    }
+
+    wl->cursor_surface = wl_compositor_create_surface(wl->compositor);
+    if (wl->cursor_surface) {
+        log_info("Cursor theme loaded for pointer enter handling");
+    } else {
+        log_error("Failed to create cursor surface");
+        wl_cursor_theme_destroy(wl->cursor_theme);
+        wl->cursor_theme = NULL;
+    }
+
     return true;
 }
 
@@ -610,6 +633,17 @@ void wayland_cleanup(void) {
             compositor_backend_cleanup(state->compositor_backend);
             state->compositor_backend = NULL;
         }
+    }
+
+    /* Destroy cursor resources */
+    if (wl->cursor_surface) {
+        wl_surface_destroy(wl->cursor_surface);
+        wl->cursor_surface = NULL;
+    }
+
+    if (wl->cursor_theme) {
+        wl_cursor_theme_destroy(wl->cursor_theme);
+        wl->cursor_theme = NULL;
     }
 
     /* Destroy Wayland objects */


### PR DESCRIPTION
## Description
<!-- Provide a brief description of your changes -->

- Fix cursor not changing to the default arrow when moving the pointer from a foreground window to the neowall wallpaper surface on wlroots-based compositors (Sway, Hyprland)
- Add `wayland-cursor` dependency and load the cursor theme at init to call `wl_pointer_set_cursor()` on pointer enter events

## Type of Change
<!-- Mark relevant items with an [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Related Issues
<!-- Link to related issues using #issue_number -->
<!-- Example: Fixes #123, Closes #456 -->

None

## Testing
<!-- Describe the tests you ran and how to reproduce them -->

- [x] Tested on compositor: Sway 1.11 <!-- e.g., Sway 1.8, Hyprland 0.32, etc. -->
- [x] Single wallpaper works
- [x] Multi-monitor setup works
- [x] Wallpaper cycling works
- [ ] Config hot-reload works (SIGHUP)
- [ ] All display modes tested (center, fill, fit, stretch, tile)
- [ ] Transitions work (if applicable)
- [x] No memory leaks (tested with valgrind) Not related.
- [x] Builds without warnings

### Test Configuration
<!-- If applicable, paste your test config here -->
```vibe
# Your test configuration here
```

## Screenshots/Videos
<!-- If your changes affect the UI or behavior, add screenshots or videos -->

Previously, if the cursor is not a normal pointer before entering the wallpaper, the cursor will not change.
<img width="384" height="204" alt="before" src="https://github.com/user-attachments/assets/1d497b72-a35e-49b2-bdb0-631f6f89b595" />

The cursor becomes a normal pointer after the fix.

## Checklist
<!-- Mark completed items with an [x] -->

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any other context about the PR here -->