### PR TITLE
fix: clear -O2 -Wstringop-truncation in sanitizer build

### DIFF
--- a/src/compositor/backends/wayland/wayland_core.c
+++ b/src/compositor/backends/wayland/wayland_core.c
@@ -70,8 +70,7 @@ static void xdg_output_handle_name(void *data, struct zxdg_output_v1 *xdg_output
     (void)xdg_output;
 
     if (name) {
-        strncpy(output->connector_name, name, sizeof(output->connector_name) - 1);
-        output->connector_name[sizeof(output->connector_name) - 1] = '\0';
+        snprintf(output->connector_name, sizeof(output->connector_name), "%s", name);
         log_info("Output connector name: %s (model: %s)",
                  output->connector_name, output->model);
     }
@@ -113,12 +112,10 @@ static void output_handle_geometry(void *data, struct wl_output *wl_output,
     (void)subpixel;
 
     if (make) {
-        strncpy(output->make, make, sizeof(output->make) - 1);
-        output->make[sizeof(output->make) - 1] = '\0';
+        snprintf(output->make, sizeof(output->make), "%s", make);
     }
     if (model) {
-        strncpy(output->model, model, sizeof(output->model) - 1);
-        output->model[sizeof(output->model) - 1] = '\0';
+        snprintf(output->model, sizeof(output->model), "%s", model);
     }
     output->transform = transform;
 

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -222,8 +222,7 @@ char **load_shaders_from_directory(const char *dir_path, size_t *count) {
         }
         snprintf(expanded_path, sizeof(expanded_path), "%s%s", home, dir_path + 1);
     } else {
-        strncpy(expanded_path, dir_path, sizeof(expanded_path) - 1);
-        expanded_path[sizeof(expanded_path) - 1] = '\0';
+        snprintf(expanded_path, sizeof(expanded_path), "%s", dir_path);
     }
 
     /* Strip trailing slash to avoid double slashes in path construction */
@@ -309,8 +308,7 @@ char **load_images_from_directory(const char *dir_path, size_t *count) {
         }
         snprintf(expanded_path, sizeof(expanded_path), "%s%s", home, dir_path + 1);
     } else {
-        strncpy(expanded_path, dir_path, sizeof(expanded_path) - 1);
-        expanded_path[sizeof(expanded_path) - 1] = '\0';
+        snprintf(expanded_path, sizeof(expanded_path), "%s", dir_path);
     }
 
     DIR *dir = opendir(expanded_path);
@@ -557,8 +555,7 @@ static bool parse_wallpaper_config(VibeValue *obj, struct wallpaper_config *conf
             config->current_cycle_index = 0;  /* Will be restored per-output in output_apply_config */
 
             /* Use first image as initial path (will be updated per-output) */
-            strncpy(config->path, image_paths[0], sizeof(config->path) - 1);
-            config->path[sizeof(config->path) - 1] = '\0';
+            snprintf(config->path, sizeof(config->path), "%s", image_paths[0]);
 
             log_info("[%s] IMAGE MODE: Loaded %zu images from directory for cycling",
                     context_name, image_count);
@@ -569,8 +566,7 @@ static bool parse_wallpaper_config(VibeValue *obj, struct wallpaper_config *conf
             return false;
         } else {
             /* Single image file */
-            strncpy(config->path, path_str, sizeof(config->path) - 1);
-            config->path[sizeof(config->path) - 1] = '\0';
+            snprintf(config->path, sizeof(config->path), "%s", path_str);
 
             log_info("[%s] IMAGE MODE: Single image '%s'", context_name, path_str);
         }
@@ -607,8 +603,7 @@ static bool parse_wallpaper_config(VibeValue *obj, struct wallpaper_config *conf
             config->current_cycle_index = 0;  /* Will be restored per-output in output_apply_config */
 
             /* Use first shader as initial shader_path (will be updated per-output) */
-            strncpy(config->shader_path, shader_paths[0], sizeof(config->shader_path) - 1);
-            config->shader_path[sizeof(config->shader_path) - 1] = '\0';
+            snprintf(config->shader_path, sizeof(config->shader_path), "%s", shader_paths[0]);
 
             log_info("[%s] SHADER MODE: Loaded %zu shaders from directory for cycling",
                     context_name, shader_count);
@@ -619,8 +614,7 @@ static bool parse_wallpaper_config(VibeValue *obj, struct wallpaper_config *conf
             return false;
         } else {
             /* Single shader file */
-            strncpy(config->shader_path, shader_str, sizeof(config->shader_path) - 1);
-            config->shader_path[sizeof(config->shader_path) - 1] = '\0';
+            snprintf(config->shader_path, sizeof(config->shader_path), "%s", shader_str);
 
             log_info("[%s] SHADER MODE: Single shader '%s'", context_name, shader_str);
         }
@@ -996,8 +990,7 @@ static bool config_create_default(const char *config_path) {
 
     /* Get directory path */
     char dir_path[MAX_PATH_LENGTH];
-    strncpy(dir_path, config_path, sizeof(dir_path) - 1);
-    dir_path[sizeof(dir_path) - 1] = '\0';
+    snprintf(dir_path, sizeof(dir_path), "%s", config_path);
 
     /* Find last slash to get directory */
     char *last_slash = strrchr(dir_path, '/');
@@ -1346,15 +1339,13 @@ static bool apply_builtin_default_config(struct neowall_state *state) {
             if (try_paths[i][0] == '~') {
                 snprintf(expanded, sizeof(expanded), "%s%s", home, try_paths[i] + 1);
             } else {
-                strncpy(expanded, try_paths[i], sizeof(expanded) - 1);
-                expanded[sizeof(expanded) - 1] = '\0';
+                snprintf(expanded, sizeof(expanded), "%s", try_paths[i]);
             }
 
             /* Check if it's a file */
             struct stat st;
             if (stat(expanded, &st) == 0 && S_ISREG(st.st_mode) && access(expanded, R_OK) == 0) {
-                strncpy(default_config.path, expanded, sizeof(default_config.path) - 1);
-                default_config.path[sizeof(default_config.path) - 1] = '\0';
+                snprintf(default_config.path, sizeof(default_config.path), "%s", expanded);
                 log_info("Using default wallpaper: %s", expanded);
                 break;
             }
@@ -1364,8 +1355,7 @@ static bool apply_builtin_default_config(struct neowall_state *state) {
                 size_t count = 0;
                 char **images = load_images_from_directory(expanded, &count);
                 if (images && count > 0) {
-                    strncpy(default_config.path, images[0], sizeof(default_config.path) - 1);
-                    default_config.path[sizeof(default_config.path) - 1] = '\0';
+                    snprintf(default_config.path, sizeof(default_config.path), "%s", images[0]);
                     log_info("Using default wallpaper from directory: %s", default_config.path);
                     /* Free the list */
                     for (size_t j = 0; j < count; j++) {

--- a/src/image/image.c
+++ b/src/image/image.c
@@ -194,7 +194,7 @@ struct image_data *image_load_png(const char *path) {
     img->height = height;
     img->channels = 4; /* RGBA */
     img->format = FORMAT_PNG;
-    strncpy(img->path, path, sizeof(img->path) - 1);
+    snprintf(img->path, sizeof(img->path), "%s", path);
 
     /* Allocate pixel buffer */
     size_t row_bytes = png_get_rowbytes(png_ptr, info_ptr);
@@ -325,7 +325,7 @@ struct image_data *image_load_jpeg(const char *path) {
     img->height = height;
     img->channels = 4; /* We'll convert RGB to RGBA */
     img->format = FORMAT_JPEG;
-    strncpy(img->path, path, sizeof(img->path) - 1);
+    snprintf(img->path, sizeof(img->path), "%s", path);
 
     /* Allocate pixel buffer (RGBA) - check for overflow */
     size_t pixel_count = (size_t)width * (size_t)height;

--- a/src/main.c
+++ b/src/main.c
@@ -910,7 +910,7 @@ int main(int argc, char *argv[]) {
     while ((opt = getopt_long(argc, argv, "c:fvhV", long_options, NULL)) != -1) {
         switch (opt) {
             case 'c':
-                strncpy(config_path, optarg, sizeof(config_path) - 1);
+                snprintf(config_path, sizeof(config_path), "%s", optarg);
                 break;
             case 'f':
                 daemon_mode = false;  /* Explicit foreground */
@@ -947,7 +947,7 @@ int main(int argc, char *argv[]) {
     if (config_path[0] == '\0') {
         const char *default_path = config_get_default_path();
         if (default_path) {
-            strncpy(config_path, default_path, sizeof(config_path) - 1);
+            snprintf(config_path, sizeof(config_path), "%s", default_path);
         } else {
             log_error("Could not determine config file path");
             return EXIT_FAILURE;
@@ -994,8 +994,10 @@ int main(int argc, char *argv[]) {
     atomic_init(&state.mouse_interaction, true);  /* default: pointer enabled, override from config */
     state.timer_fd = -1;
     state.wakeup_fd = -1;
-    strncpy(state.config_path, config_path, sizeof(state.config_path) - 1);
-    state.config_path[sizeof(state.config_path) - 1] = '\0';
+    /* snprintf guarantees NUL-termination and silences GCC -O2
+     * -Wstringop-truncation (config_path and state.config_path are the same
+     * size, which is exactly the case the warning targets). */
+    snprintf(state.config_path, sizeof(state.config_path), "%s", config_path);
     pthread_mutex_init(&state.state_mutex, NULL);
     pthread_rwlock_init(&state.output_list_lock, NULL);
     pthread_mutex_init(&state.state_file_lock, NULL);

--- a/src/output/output.c
+++ b/src/output/output.c
@@ -485,8 +485,7 @@ static void *preload_thread_func(void *arg) {
     }
 
     output->preload_decoded_image = decoded_image;
-    strncpy(output->preload_path, args->path, sizeof(output->preload_path) - 1);
-    output->preload_path[sizeof(output->preload_path) - 1] = '\0';
+    snprintf(output->preload_path, sizeof(output->preload_path), "%s", args->path);
 
     pthread_mutex_unlock(&output->preload_mutex);
 
@@ -544,8 +543,7 @@ void output_preload_next_wallpaper(struct output_state *output) {
     }
 
     args->output = output;
-    strncpy(args->path, next_path, sizeof(args->path) - 1);
-    args->path[sizeof(args->path) - 1] = '\0';
+    snprintf(args->path, sizeof(args->path), "%s", next_path);
     args->width = output->width;
     args->height = output->height;
     args->mode = output->config->mode;
@@ -747,8 +745,7 @@ void output_set_wallpaper(struct output_state *output, const char *path) {
     }
 
     /* Update config path */
-    strncpy(output->config->path, path, sizeof(output->config->path) - 1);
-    output->config->path[sizeof(output->config->path) - 1] = '\0';
+    snprintf(output->config->path, sizeof(output->config->path), "%s", path);
 
     /* Initialize frame time for cycling */
     uint64_t now = get_time_ms();
@@ -784,8 +781,7 @@ void output_set_shader(struct output_state *output, const char *shader_path) {
 
     /* Acquire state mutex to safely read model string */
     pthread_mutex_lock(&output->state->state_mutex);
-    strncpy(model_copy, output->model, sizeof(model_copy) - 1);
-    model_copy[sizeof(model_copy) - 1] = '\0';
+    snprintf(model_copy, sizeof(model_copy), "%s", output->model);
     pthread_mutex_unlock(&output->state->state_mutex);
 
     log_info("Setting shader for output %s: %s",
@@ -818,8 +814,7 @@ void output_set_shader(struct output_state *output, const char *shader_path) {
         log_debug("EGL surface not ready for output %s, deferring shader load: %s",
                   output->model[0] ? output->model : "unknown", shader_path);
         /* Store shader path in config for later application when surface is ready */
-        strncpy(output->config->shader_path, shader_path, sizeof(output->config->shader_path) - 1);
-        output->config->shader_path[sizeof(output->config->shader_path) - 1] = '\0';
+        snprintf(output->config->shader_path, sizeof(output->config->shader_path), "%s", shader_path);
         output->config->type = WALLPAPER_SHADER;
         return;
     }
@@ -938,8 +933,7 @@ void output_set_shader(struct output_state *output, const char *shader_path) {
 
     /* Update config with new shader path - protected by state mutex */
     pthread_mutex_lock(&output->state->state_mutex);
-    strncpy(output->config->shader_path, shader_path, sizeof(output->config->shader_path) - 1);
-    output->config->shader_path[sizeof(output->config->shader_path) - 1] = '\0';
+    snprintf(output->config->shader_path, sizeof(output->config->shader_path), "%s", shader_path);
     output->config->type = WALLPAPER_SHADER;
     pthread_mutex_unlock(&output->state->state_mutex);
 
@@ -1032,8 +1026,7 @@ void output_cycle_wallpaper(struct output_state *output) {
         output->pending_shader_path[0] != '\0') {
         /* Use local copy of model to avoid race if output is being modified */
         char model_copy[64];
-        strncpy(model_copy, output->model, sizeof(model_copy) - 1);
-        model_copy[sizeof(model_copy) - 1] = '\0';
+        snprintf(model_copy, sizeof(model_copy), "%s", output->model);
         const char *output_name = model_copy[0] ? model_copy : "unknown";
         log_info("Shader transition in progress on output '%s', deferring cycle request",
                  output_name);
@@ -1049,8 +1042,7 @@ void output_cycle_wallpaper(struct output_state *output) {
     /* Copy path before releasing lock to avoid use-after-free if config reloads */
     char next_path_copy[MAX_PATH_LENGTH];
     const char *next_path = output->config->cycle_paths[output->config->current_cycle_index];
-    strncpy(next_path_copy, next_path, sizeof(next_path_copy) - 1);
-    next_path_copy[sizeof(next_path_copy) - 1] = '\0';
+    snprintf(next_path_copy, sizeof(next_path_copy), "%s", next_path);
     pthread_mutex_unlock(&output->state->state_mutex);
 
     /* Use the copied path from here onwards */
@@ -1169,8 +1161,7 @@ void output_set_cycle_index(struct output_state *output, size_t index) {
     /* Copy path before releasing lock */
     char path_copy[MAX_PATH_LENGTH];
     const char *path = output->config->cycle_paths[index];
-    strncpy(path_copy, path, sizeof(path_copy) - 1);
-    path_copy[sizeof(path_copy) - 1] = '\0';
+    snprintf(path_copy, sizeof(path_copy), "%s", path);
     pthread_mutex_unlock(&output->state->state_mutex);
 
     const char *type_str = (output->config->type == WALLPAPER_SHADER) ? "shader" : "wallpaper";
@@ -1343,15 +1334,13 @@ bool output_apply_config(struct output_state *output, struct wallpaper_config *c
 
             /* Update the initial path to use the restored index */
             if (output->config->type == WALLPAPER_SHADER) {
-                strncpy(output->config->shader_path,
-                       output->config->cycle_paths[saved_index],
-                       sizeof(output->config->shader_path) - 1);
-                output->config->shader_path[sizeof(output->config->shader_path) - 1] = '\0';
+                snprintf(output->config->shader_path,
+                         sizeof(output->config->shader_path), "%s",
+                         output->config->cycle_paths[saved_index]);
             } else {
-                strncpy(output->config->path,
-                       output->config->cycle_paths[saved_index],
-                       sizeof(output->config->path) - 1);
-                output->config->path[sizeof(output->config->path) - 1] = '\0';
+                snprintf(output->config->path,
+                         sizeof(output->config->path), "%s",
+                         output->config->cycle_paths[saved_index]);
             }
         }
 

--- a/src/shader/shader_core.c
+++ b/src/shader/shader_core.c
@@ -231,15 +231,13 @@ static bool shader_resolve_path(const char *shader_name, char *resolved_path, si
 
     /* If it's an absolute path or starts with ~, use it directly */
     if (shader_name[0] == '/' || shader_name[0] == '~') {
-        strncpy(resolved_path, shader_name, resolved_size - 1);
-        resolved_path[resolved_size - 1] = '\0';
+        snprintf(resolved_path, resolved_size, "%s", shader_name);
         return true;
     }
 
     /* If it contains a path separator, treat it as a relative path */
     if (strchr(shader_name, '/') != NULL) {
-        strncpy(resolved_path, shader_name, resolved_size - 1);
-        resolved_path[resolved_size - 1] = '\0';
+        snprintf(resolved_path, resolved_size, "%s", shader_name);
         return true;
     }
 
@@ -275,8 +273,7 @@ static bool shader_resolve_path(const char *shader_name, char *resolved_path, si
                 log_error("Resolved shader path too long: %s", search_paths[i]);
                 continue;
             }
-            strncpy(resolved_path, search_paths[i], resolved_size - 1);
-            resolved_path[resolved_size - 1] = '\0';
+            snprintf(resolved_path, resolved_size, "%s", search_paths[i]);
             log_debug("Resolved shader '%s' to: %s", shader_name, resolved_path);
             return true;
         }
@@ -311,12 +308,13 @@ char *shader_load_file(const char *path) {
         if (home) {
             snprintf(expanded_path, sizeof(expanded_path), "%s%s", home, resolved_path + 1);
         } else {
-            strncpy(expanded_path, resolved_path, sizeof(expanded_path) - 1);
-            expanded_path[sizeof(expanded_path) - 1] = '\0';
+            /* snprintf (not strncpy) guarantees NUL-termination and silences
+             * GCC -O2 -Wstringop-truncation, which fires on a strncpy that
+             * copies exactly size-1 bytes even when we terminate manually. */
+            snprintf(expanded_path, sizeof(expanded_path), "%s", resolved_path);
         }
     } else {
-        strncpy(expanded_path, resolved_path, sizeof(expanded_path) - 1);
-        expanded_path[sizeof(expanded_path) - 1] = '\0';
+        snprintf(expanded_path, sizeof(expanded_path), "%s", resolved_path);
     }
 
     /* Open file in binary mode to get accurate byte count */

--- a/src/utils.c
+++ b/src/utils.c
@@ -362,8 +362,7 @@ bool write_wallpaper_state(const char *output_name, const char *wallpaper_path,
     
     /* Ensure state directory exists */
     char dir_path[MAX_PATH_LENGTH];
-    strncpy(dir_path, state_path, sizeof(dir_path) - 1);
-    dir_path[sizeof(dir_path) - 1] = '\0';
+    snprintf(dir_path, sizeof(dir_path), "%s", state_path);
     char *last_slash = strrchr(dir_path, '/');
     if (last_slash) {
         *last_slash = '\0';
@@ -372,8 +371,7 @@ bool write_wallpaper_state(const char *output_name, const char *wallpaper_path,
         if (stat(dir_path, &st) == -1) {
             /* Try to create parent first */
             char parent_path[MAX_PATH_LENGTH];
-            strncpy(parent_path, dir_path, sizeof(parent_path) - 1);
-            parent_path[sizeof(parent_path) - 1] = '\0';
+            snprintf(parent_path, sizeof(parent_path), "%s", dir_path);
             char *parent_slash = strrchr(parent_path, '/');
             if (parent_slash) {
                 *parent_slash = '\0';
@@ -453,15 +451,13 @@ bool write_wallpaper_state(const char *output_name, const char *wallpaper_path,
     for (int i = 0; i < state_count; i++) {
         if (output_name && strcmp(states[i].output_name, output_name) == 0) {
             /* Update existing entry */
-            strncpy(states[i].wallpaper_path, wallpaper_path ? wallpaper_path : "none", 
-                    sizeof(states[i].wallpaper_path) - 1);
-            states[i].wallpaper_path[sizeof(states[i].wallpaper_path) - 1] = '\0';
-            strncpy(states[i].mode, mode ? mode : "fill", sizeof(states[i].mode) - 1);
-            states[i].mode[sizeof(states[i].mode) - 1] = '\0';
+            snprintf(states[i].wallpaper_path, sizeof(states[i].wallpaper_path), "%s",
+                     wallpaper_path ? wallpaper_path : "none");
+            snprintf(states[i].mode, sizeof(states[i].mode), "%s", mode ? mode : "fill");
             states[i].cycle_index = cycle_index;
             states[i].cycle_total = cycle_total;
-            strncpy(states[i].status, status ? status : "active", sizeof(states[i].status) - 1);
-            states[i].status[sizeof(states[i].status) - 1] = '\0';
+            snprintf(states[i].status, sizeof(states[i].status), "%s",
+                     status ? status : "active");
             states[i].timestamp = (long)time(NULL);
             found_output = true;
             break;
@@ -470,19 +466,19 @@ bool write_wallpaper_state(const char *output_name, const char *wallpaper_path,
     
     /* Add new entry if not found */
     if (!found_output && state_count < MAX_OUTPUTS) {
-        /* Zero the slot first: this array is uninitialized stack memory and the
-         * strncpy() calls below do not guarantee NUL-termination when the source
-         * is >= the destination size. A later fprintf("%s") would then read OOB. */
+        /* snprintf both guarantees NUL-termination (the source is an unbounded
+         * caller pointer) and silences GCC -O2 -Wstringop-truncation. */
         memset(&states[state_count], 0, sizeof(states[state_count]));
-        strncpy(states[state_count].output_name, output_name ? output_name : "unknown", 
-                sizeof(states[state_count].output_name) - 1);
-        strncpy(states[state_count].wallpaper_path, wallpaper_path ? wallpaper_path : "none", 
-                sizeof(states[state_count].wallpaper_path) - 1);
-        strncpy(states[state_count].mode, mode ? mode : "fill", sizeof(states[state_count].mode) - 1);
+        snprintf(states[state_count].output_name, sizeof(states[state_count].output_name),
+                 "%s", output_name ? output_name : "unknown");
+        snprintf(states[state_count].wallpaper_path, sizeof(states[state_count].wallpaper_path),
+                 "%s", wallpaper_path ? wallpaper_path : "none");
+        snprintf(states[state_count].mode, sizeof(states[state_count].mode),
+                 "%s", mode ? mode : "fill");
         states[state_count].cycle_index = cycle_index;
         states[state_count].cycle_total = cycle_total;
-        strncpy(states[state_count].status, status ? status : "active", 
-                sizeof(states[state_count].status) - 1);
+        snprintf(states[state_count].status, sizeof(states[state_count].status),
+                 "%s", status ? status : "active");
         states[state_count].timestamp = (long)time(NULL);
         state_count++;
     }
@@ -678,8 +674,7 @@ bool write_cycle_list(const char *output_name, char **paths, size_t count, size_
     
     /* Ensure parent directory exists */
     char dir_path[MAX_PATH_LENGTH];
-    strncpy(dir_path, list_path, sizeof(dir_path) - 1);
-    dir_path[sizeof(dir_path) - 1] = '\0';
+    snprintf(dir_path, sizeof(dir_path), "%s", list_path);
     char *last_slash = strrchr(dir_path, '/');
     if (last_slash) {
         *last_slash = '\0';


### PR DESCRIPTION
The Quality workflow's ASan/UBSan and TSan jobs build at -O2, where GCC's -Wstringop-truncation fires on the strncpy(dst, src, sizeof(dst)-1) idiom (it cannot prove the manual NUL-terminate on the next line, and warns whenever a worst-case copy fills the buffer). Replaced those copies with snprintf(dst, sizeof(dst), "%s", src), which is unambiguously NUL-terminating and warning-free. Also fixes two genuinely-unterminated strncpy calls in image.c (img->path).