### PR TITLE
fix: address clang static-analyzer findings

### DIFF
--- a/include/neowall/constants.h
+++ b/include/neowall/constants.h
@@ -22,7 +22,7 @@
 #define SHADER_FADE_OUT_MS      400
 
 /* Polling and sleep intervals */
-#define POLL_TIMEOUT_INFINITE   -1
+#define POLL_TIMEOUT_INFINITE   (-1)
 #define SLEEP_100MS_NS          100000000  /* 100ms in nanoseconds */
 #define STATS_INTERVAL_MS       10000      /* Print stats every 10 seconds */
 

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -1311,6 +1311,13 @@ return true;
  * ============================================================================ */
 
 static bool apply_builtin_default_config(struct neowall_state *state) {
+    /* config_load() forwards a NULL state straight here on its early-out path,
+     * so guard before dereferencing state->output_list_lock below. */
+    if (!state) {
+        log_error("Cannot apply built-in default config: state is NULL");
+        return false;
+    }
+
     log_info("Applying built-in default configuration");
 
     /* Create a minimal working config */

--- a/src/config/vibe.c
+++ b/src/config/vibe.c
@@ -351,7 +351,8 @@ static Token next_token(VibeParser* parser) {
         if (c == '-' && parser->pos + 1 < parser->length && isdigit(parser->input[parser->pos + 1])) {
             parser->pos++;
             parser->column++;
-            c = parser->input[parser->pos];
+            /* c is re-read at the top of the collection loop below; no need to
+             * reassign it here. */
         }
 
         /* Collect all valid unquoted string characters */
@@ -811,14 +812,23 @@ VibeValue* vibe_parse_file(VibeParser* parser, const char* filename) {
     long size = ftell(file);
     fseek(file, 0, SEEK_SET);
 
-    char* buffer = malloc(size + 1);
+    /* ftell() returns -1 on error (e.g. an unseekable stream). Guard against it
+     * so malloc(size + 1) isn't malloc(0) and fread()'s size argument doesn't
+     * wrap to SIZE_MAX. */
+    if (size < 0) {
+        fclose(file);
+        set_error(parser, "Cannot determine size of file '%s'", filename);
+        return NULL;
+    }
+
+    char* buffer = malloc((size_t)size + 1);
     if (!buffer) {
         fclose(file);
         set_error(parser, "Memory allocation failed");
         return NULL;
     }
 
-    size_t bytes_read = fread(buffer, 1, size, file);
+    size_t bytes_read = fread(buffer, 1, (size_t)size, file);
     buffer[bytes_read] = '\0';
     fclose(file);
 

--- a/src/image/image.c
+++ b/src/image/image.c
@@ -674,8 +674,10 @@ static struct image_data *image_scale_to_display(struct image_data *img, int32_t
         return img;
     }
     
-    /* Calculate optimal dimensions for this display mode */
-    uint32_t target_width, target_height;
+    /* Calculate optimal dimensions for this display mode. Initialised here so
+     * the static analyzer can see both are always defined even if a future
+     * mode is added to calculate_optimal_dimensions without setting them. */
+    uint32_t target_width = img->width, target_height = img->height;
     calculate_optimal_dimensions(img->width, img->height, display_width, display_height,
                                  mode, &target_width, &target_height);
     


### PR DESCRIPTION
Follow-up to #42. Fixes genuine clang static-analyzer findings:

- config.c: guard NULL state in apply_builtin_default_config (real null-deref via config_load(NULL))
- vibe.c: guard negative ftell result before malloc/fread
- vibe.c: remove dead store in parser
- constants.h: parenthesize POLL_TIMEOUT_INFINITE macro
- image.c: initialize target dimensions before calculate_optimal_dimensions