### PR TITLE
Change documentation for transition_duration to seconds

### DIFF
--- a/config/docs/CONFIG.md
+++ b/config/docs/CONFIG.md
@@ -175,13 +175,13 @@ Only applies to image cycling, not shaders.
 
 #### `transition_duration` - Transition Speed
 
-Transition length in milliseconds:
+Transition length in seconds:
 
 ```vibe
-transition_duration 300   # Default
-transition_duration 100   # Fast
-transition_duration 500   # Smooth
-transition_duration 1000  # Slow
+transition_duration 0.3   # Default
+transition_duration 0.1   # Fast
+transition_duration 5     # Smooth
+transition_duration 10    # Slow
 ```
 
 ## Global Options


### PR DESCRIPTION
Code currently uses seconds, and gives non useful prompts if the values are in ms.

## Description
Documentation updated to match current functionality

## Type of Change
<!-- Mark relevant items with an [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Related Issues
None

Fixes #

## Testing
<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Tested on compositor: <!-- e.g., Sway 1.8, Hyprland 0.32, etc. -->
- [ ] Single wallpaper works
- [ ] Multi-monitor setup works
- [ ] Wallpaper cycling works
- [ ] Config hot-reload works (SIGHUP)
- [ ] All display modes tested (center, fill, fit, stretch, tile)
- [ ] Transitions work (if applicable)
- [ ] No memory leaks (tested with valgrind)
- [ ] Builds without warnings

### Test Configuration
<!-- If applicable, paste your test config here -->
```vibe
# Your test configuration here
```

## Screenshots/Videos
<!-- If your changes affect the UI or behavior, add screenshots or videos -->

## Checklist
<!-- Mark completed items with an [x] -->

- [ ] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any other context about the PR here -->