### PR TITLE
Honor JPEG EXIF orientation + add shuffle option for cycle order

### DIFF
--- a/config/docs/CONFIG.md
+++ b/config/docs/CONFIG.md
@@ -184,6 +184,27 @@ transition_duration 500   # Smooth
 transition_duration 1000  # Slow
 ```
 
+#### `shuffle` - Randomise Cycle Order
+
+Randomise the order of a directory cycle. Works for both image directories
+and shader directories.
+
+```vibe
+shuffle true    # Random order, fresh permutation every wrap
+shuffle false   # Alphabetical order (default)
+```
+
+- Applied at startup so each launch is a different sequence.
+- Re-applied every time the cycle wraps, so a long-running daemon doesn't
+  settle into a fixed loop. The just-shown wallpaper is held back from
+  position 0 on the new pass so the same item never appears twice in a row.
+- All monitors that share a config block see the **same** shuffled order,
+  so multi-monitor synchronised cycling keeps working.
+- Saved cycle position (the bookmark used to resume where you left off after
+  a daemon restart) is disabled under `shuffle true` — the saved index
+  refers to a different random permutation than the one you'd get on the
+  next launch, so resuming at it is meaningless.
+
 ## Global Options
 
 These sit at the top level of `config.vibe`, **outside** any `default {}` or
@@ -283,6 +304,18 @@ default {
 default {
   path ~/Pictures/Wallpapers/
   duration 300
+  transition fade
+  mode fill
+}
+```
+
+### Shuffled Cycle
+
+```vibe
+default {
+  path ~/Pictures/Wallpapers/
+  duration 300
+  shuffle true
   transition fade
   mode fill
 }

--- a/config/neowall.vibe
+++ b/config/neowall.vibe
@@ -90,6 +90,13 @@ default {
   # Examples: 100 (fast), 300 (default), 500 (smooth), 1000 (slow)
   transition_duration 300
 
+  # Randomise the cycle order for directory cycling (optional, default: false).
+  # Works for both image directories and shader directories. The list is
+  # re-shuffled every time it wraps so a long-running daemon doesn't settle
+  # into a fixed loop. The just-shown wallpaper is held back from position 0
+  # on the new pass so the same item never repeats back-to-back.
+  # shuffle true
+
   # Pause rendering when a fullscreen window covers this output (default: true)
   # Saves GPU/CPU when the wallpaper isn't visible (fullscreen, maximized, etc.)
   # Requires compositor support: wlr-foreign-toplevel on Wayland, EWMH on X11

--- a/include/neowall/config/config.h
+++ b/include/neowall/config/config.h
@@ -23,4 +23,9 @@ const char *config_get_default_path(void);
 char **load_images_from_directory(const char *dir_path, size_t *count);
 char **load_shaders_from_directory(const char *dir_path, size_t *count);
 
+/* Fisher-Yates shuffle of an array of cycle path pointers (issue #47).
+ * keep_first_at_zero=true preserves paths[0] (used on wrap so the just-shown
+ * item doesn't repeat). The RNG is seeded lazily on first call. */
+void config_shuffle_cycle_paths(char **paths, size_t n, bool keep_first_at_zero);
+
 #endif /* CONFIG_H */

--- a/include/neowall/output/output.h
+++ b/include/neowall/output/output.h
@@ -61,6 +61,8 @@ struct wallpaper_config {
     bool pause_on_fullscreen;           /* Pause rendering when output is occluded by fullscreen window */
     float pause_coverage_threshold;     /* Fraction (0.0-1.0) of wallpaper region that must be covered by tiled windows to count as occluded. Default 0.8 */
     bool cycle;                         /* Enable wallpaper cycling */
+    bool shuffle;                       /* Randomise cycle order on load + on every wrap (issue #47).
+                                         * Applies to both image and shader directory cycles. */
     char **cycle_paths;                 /* Array of paths for cycling */
     size_t cycle_count;                 /* Number of wallpapers to cycle */
     size_t current_cycle_index;         /* Current index in cycle */

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -9,6 +9,7 @@
 #include <unistd.h>
 #include <strings.h>
 #include <dirent.h>
+#include <time.h>
 #include "neowall/config/config.h"
 #include "neowall/config/vibe.h"
 #include "neowall/neowall.h"
@@ -199,6 +200,43 @@ static int compare_strings(const void *a, const void *b) {
     const char *str_a = *(const char **)a;
     const char *str_b = *(const char **)b;
     return strcmp(str_a, str_b);
+}
+
+/* Fisher-Yates shuffle on an array of cycle path pointers (issue #47).
+ *
+ * Uses random() (POSIX, ~31-bit period — fine for picking a wallpaper order),
+ * seeded once per process from CLOCK_MONOTONIC + getpid() so two daemons started
+ * in the same second don't pick the same sequence. The seed is intentionally
+ * lazy: a shader/image cycle that's never built never touches the RNG.
+ *
+ * `keep_first_at_zero` is the "re-shuffle on wrap" mode: it shuffles only
+ * indices [1, n) so the wallpaper that was just shown stays at position 0,
+ * preventing the same image appearing twice in a row across a wrap. */
+void config_shuffle_cycle_paths(char **paths, size_t n, bool keep_first_at_zero) {
+    if (!paths || n < 2) return;
+
+    static bool seeded = false;
+    if (!seeded) {
+        struct timespec ts;
+        clock_gettime(CLOCK_MONOTONIC, &ts);
+        unsigned int seed = (unsigned int)ts.tv_nsec
+                          ^ (unsigned int)(ts.tv_sec << 16)
+                          ^ (unsigned int)getpid();
+        srandom(seed);
+        seeded = true;
+    }
+
+    size_t start = keep_first_at_zero ? 1 : 0;
+    if (n - start < 2) return;
+
+    /* Standard Fisher-Yates: walk from the end down, swap with a random
+     * earlier (or same) slot. Uniform if random() is uniform on [0, RAND_MAX]. */
+    for (size_t i = n - 1; i > start; i--) {
+        size_t j = start + (size_t)(random() % (long)(i - start + 1));
+        char *tmp = paths[i];
+        paths[i] = paths[j];
+        paths[j] = tmp;
+    }
 }
 
 /* ============================================================================
@@ -484,6 +522,7 @@ static void init_wallpaper_config_defaults(struct wallpaper_config *config) {
     config->pause_on_fullscreen = true;  /* Default: pause rendering when occluded */
     config->pause_coverage_threshold = 0.8f;  /* Default: 80% tiled coverage = occluded */
     config->cycle = false;
+    config->shuffle = false;
     config->cycle_paths = NULL;
     config->cycle_count = 0;
     config->current_cycle_index = 0;
@@ -501,6 +540,18 @@ static bool parse_wallpaper_config(VibeValue *obj, struct wallpaper_config *conf
 
     /* Initialize with safe defaults */
     init_wallpaper_config_defaults(config);
+
+    /* Parse 'shuffle' EARLY — needs to be in scope before the directory
+     * branches below so we can apply it the moment cycle_paths is built. */
+    VibeValue *shuffle_val = vibe_object_get(obj->as_object, "shuffle");
+    if (shuffle_val) {
+        if (shuffle_val->type != VIBE_TYPE_BOOLEAN) {
+            log_error("[%s] 'shuffle' must be a boolean (true or false), got type: %d",
+                     context_name, shuffle_val->type);
+            return false;
+        }
+        config->shuffle = shuffle_val->as_boolean;
+    }
 
     /* Check for 'path' and 'shader' - these are MUTUALLY EXCLUSIVE */
     VibeValue *path_val = vibe_object_get(obj->as_object, "path");
@@ -554,6 +605,16 @@ static bool parse_wallpaper_config(VibeValue *obj, struct wallpaper_config *conf
             config->cycle_paths = image_paths;
             config->current_cycle_index = 0;  /* Will be restored per-output in output_apply_config */
 
+            /* Randomise order if requested (issue #47). Done here so every
+             * downstream consumer — per-output deep copy, write_cycle_list for
+             * `neowall list`, multi-monitor sync — sees the SAME shuffled
+             * order. Two monitors sharing this default block stay in sync. */
+            if (config->shuffle) {
+                config_shuffle_cycle_paths(config->cycle_paths, config->cycle_count, false);
+                log_info("[%s] IMAGE MODE: shuffle=true, randomised %zu-entry cycle order",
+                        context_name, image_count);
+            }
+
             /* Use first image as initial path (will be updated per-output) */
             snprintf(config->path, sizeof(config->path), "%s", image_paths[0]);
 
@@ -601,6 +662,15 @@ static bool parse_wallpaper_config(VibeValue *obj, struct wallpaper_config *conf
             config->cycle_count = shader_count;
             config->cycle_paths = shader_paths;
             config->current_cycle_index = 0;  /* Will be restored per-output in output_apply_config */
+
+            /* Randomise order if requested (issue #47). Same reasoning as the
+             * image branch above — shuffle before the per-output deep copy so
+             * everyone sees the same order. */
+            if (config->shuffle) {
+                config_shuffle_cycle_paths(config->cycle_paths, config->cycle_count, false);
+                log_info("[%s] SHADER MODE: shuffle=true, randomised %zu-entry cycle order",
+                        context_name, shader_count);
+            }
 
             /* Use first shader as initial shader_path (will be updated per-output) */
             snprintf(config->shader_path, sizeof(config->shader_path), "%s", shader_paths[0]);
@@ -927,7 +997,7 @@ static bool parse_wallpaper_config(VibeValue *obj, struct wallpaper_config *conf
     const char *known_keys[] = {
         "path", "shader", "mode", "duration", "transition",
         "transition_duration", "shader_speed", "channels", "shader_fps", "vsync", "show_fps",
-        "pause_on_fullscreen", "pause_coverage_threshold"
+        "pause_on_fullscreen", "pause_coverage_threshold", "shuffle"
     };
     size_t known_key_count = sizeof(known_keys) / sizeof(known_keys[0]);
 

--- a/src/image/image.c
+++ b/src/image/image.c
@@ -250,6 +250,135 @@ static void jpeg_error_exit(j_common_ptr cinfo) {
     longjmp(err->setjmp_buffer, 1);
 }
 
+/* EXIF orientation values per TIFF/EP. 1 = identity. */
+enum exif_orientation {
+    EXIF_ORIENT_TOP_LEFT       = 1, /* identity */
+    EXIF_ORIENT_TOP_RIGHT      = 2, /* mirror horizontal */
+    EXIF_ORIENT_BOTTOM_RIGHT   = 3, /* rotate 180 */
+    EXIF_ORIENT_BOTTOM_LEFT    = 4, /* mirror vertical */
+    EXIF_ORIENT_LEFT_TOP       = 5, /* mirror horizontal + rotate 270 CW */
+    EXIF_ORIENT_RIGHT_TOP      = 6, /* rotate 90 CW */
+    EXIF_ORIENT_RIGHT_BOTTOM   = 7, /* mirror horizontal + rotate 90 CW */
+    EXIF_ORIENT_LEFT_BOTTOM    = 8, /* rotate 270 CW (== 90 CCW) */
+};
+
+/* Little helper: read u16/u32 honoring TIFF byte order. */
+static uint16_t exif_u16(const uint8_t *p, bool be) {
+    return be ? (uint16_t)((p[0] << 8) | p[1])
+              : (uint16_t)((p[1] << 8) | p[0]);
+}
+static uint32_t exif_u32(const uint8_t *p, bool be) {
+    return be ? ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) | ((uint32_t)p[2] << 8) | p[3]
+              : ((uint32_t)p[3] << 24) | ((uint32_t)p[2] << 16) | ((uint32_t)p[1] << 8) | p[0];
+}
+
+/* Parse an APP1 (EXIF) marker payload and return the Orientation tag value.
+ * `data` is the bytes AFTER the marker length field (i.e. starting with the
+ * "Exif\0\0" signature). Returns 1 (identity) if anything looks off — we treat
+ * malformed EXIF as "no rotation" rather than failing the whole decode. */
+static int exif_parse_orientation(const uint8_t *data, size_t len) {
+    /* APP1 EXIF signature: "Exif\0\0" (6 bytes) followed by the TIFF header. */
+    if (len < 6 + 8) return EXIF_ORIENT_TOP_LEFT;
+    if (memcmp(data, "Exif\0\0", 6) != 0) return EXIF_ORIENT_TOP_LEFT;
+
+    const uint8_t *tiff = data + 6;
+    size_t tiff_len = len - 6;
+
+    bool be;
+    if (tiff[0] == 'M' && tiff[1] == 'M') be = true;
+    else if (tiff[0] == 'I' && tiff[1] == 'I') be = false;
+    else return EXIF_ORIENT_TOP_LEFT;
+
+    if (exif_u16(tiff + 2, be) != 0x002A) return EXIF_ORIENT_TOP_LEFT;
+
+    uint32_t ifd0_off = exif_u32(tiff + 4, be);
+    if (ifd0_off + 2 > tiff_len) return EXIF_ORIENT_TOP_LEFT;
+
+    uint16_t n_entries = exif_u16(tiff + ifd0_off, be);
+    /* Each IFD entry is 12 bytes. Cap at a sane bound to avoid pathological files. */
+    if (n_entries > 1024) return EXIF_ORIENT_TOP_LEFT;
+    if ((size_t)ifd0_off + 2 + (size_t)n_entries * 12 > tiff_len) return EXIF_ORIENT_TOP_LEFT;
+
+    for (uint16_t i = 0; i < n_entries; i++) {
+        const uint8_t *e = tiff + ifd0_off + 2 + (size_t)i * 12;
+        uint16_t tag  = exif_u16(e, be);
+        uint16_t type = exif_u16(e + 2, be);
+        uint32_t cnt  = exif_u32(e + 4, be);
+        if (tag == 0x0112 /* Orientation */ && type == 3 /* SHORT */ && cnt >= 1) {
+            /* SHORT inline value sits in the first 2 bytes of the value field;
+             * for big-endian that's e+8, little-endian also e+8 (low byte first). */
+            uint16_t v = exif_u16(e + 8, be);
+            if (v >= 1 && v <= 8) return (int)v;
+            return EXIF_ORIENT_TOP_LEFT;
+        }
+    }
+    return EXIF_ORIENT_TOP_LEFT;
+}
+
+/* Apply an EXIF orientation to an RGBA pixel buffer in place (new buffer
+ * allocated, old one freed). Width/height in `img` are updated when the
+ * orientation transposes the axes. No-op for orientation 1. */
+static void image_apply_exif_orientation(struct image_data *img, int orientation) {
+    if (!img || !img->pixels || orientation == EXIF_ORIENT_TOP_LEFT) {
+        return;
+    }
+    if (orientation < 1 || orientation > 8) {
+        return;
+    }
+
+    const uint32_t w = img->width;
+    const uint32_t h = img->height;
+    const bool transpose = (orientation >= 5);
+    const uint32_t nw = transpose ? h : w;
+    const uint32_t nh = transpose ? w : h;
+
+    /* Overflow guard. The product nw*nh*4 must fit in size_t (already validated
+     * pre-rotation in the loader, but transpose changes which axis is the long
+     * one, so re-check). On 64-bit (size_t == uint64_t) `nw > SIZE_MAX/4` is
+     * tautologically false for uint32_t — only the nh-multiplied bound matters. */
+    if (nh != 0 && (size_t)nw * 4 > SIZE_MAX / nh) {
+        return;
+    }
+    uint8_t *dst = malloc((size_t)nw * nh * 4);
+    if (!dst) {
+        log_warn("EXIF orient: alloc failed, leaving image as-is");
+        return;
+    }
+
+    const uint8_t *src = img->pixels;
+    /* For each (sx,sy) source pixel, compute its destination (dx,dy) per the
+     * EXIF transform, then copy the 4 RGBA bytes. Walking the source linearly
+     * keeps cache behaviour predictable on the hot read side. */
+    for (uint32_t sy = 0; sy < h; sy++) {
+        for (uint32_t sx = 0; sx < w; sx++) {
+            uint32_t dx = 0, dy = 0;
+            switch (orientation) {
+                case EXIF_ORIENT_TOP_RIGHT:    dx = w - 1 - sx; dy = sy;            break;
+                case EXIF_ORIENT_BOTTOM_RIGHT: dx = w - 1 - sx; dy = h - 1 - sy;    break;
+                case EXIF_ORIENT_BOTTOM_LEFT:  dx = sx;         dy = h - 1 - sy;    break;
+                case EXIF_ORIENT_LEFT_TOP:     dx = sy;         dy = sx;            break;
+                case EXIF_ORIENT_RIGHT_TOP:    dx = h - 1 - sy; dy = sx;            break;
+                case EXIF_ORIENT_RIGHT_BOTTOM: dx = h - 1 - sy; dy = w - 1 - sx;    break;
+                case EXIF_ORIENT_LEFT_BOTTOM:  dx = sy;         dy = w - 1 - sx;    break;
+                default:                       dx = sx;         dy = sy;            break;
+            }
+            size_t s = ((size_t)sy * w + sx) * 4;
+            size_t d = ((size_t)dy * nw + dx) * 4;
+            dst[d + 0] = src[s + 0];
+            dst[d + 1] = src[s + 1];
+            dst[d + 2] = src[s + 2];
+            dst[d + 3] = src[s + 3];
+        }
+    }
+
+    free(img->pixels);
+    img->pixels = dst;
+    img->width  = nw;
+    img->height = nh;
+    log_debug("Applied EXIF orientation %d (%ux%u -> %ux%u)",
+              orientation, w, h, nw, nh);
+}
+
 /* Load JPEG image */
 struct image_data *image_load_jpeg(const char *path) {
     if (!path) {
@@ -286,11 +415,25 @@ struct image_data *image_load_jpeg(const char *path) {
     /* Create decompression struct */
     jpeg_create_decompress(&cinfo);
 
+    /* Ask libjpeg to keep APP1 markers around so we can read EXIF orientation
+     * after the header is parsed. Must be called BEFORE jpeg_read_header. */
+    jpeg_save_markers(&cinfo, JPEG_APP0 + 1, 0xFFFF);
+
     /* Specify data source */
     jpeg_stdio_src(&cinfo, fp);
 
     /* Read JPEG header */
     jpeg_read_header(&cinfo, TRUE);
+
+    /* Walk saved markers for an APP1 EXIF payload (issue #48). */
+    int exif_orientation = EXIF_ORIENT_TOP_LEFT;
+    for (jpeg_saved_marker_ptr m = cinfo.marker_list; m != NULL; m = m->next) {
+        if (m->marker == JPEG_APP0 + 1 && m->data_length >= 6 &&
+            memcmp(m->data, "Exif\0\0", 6) == 0) {
+            exif_orientation = exif_parse_orientation(m->data, m->data_length);
+            break;
+        }
+    }
 
     /* Force RGB output */
     cinfo.out_color_space = JCS_RGB;
@@ -384,7 +527,15 @@ struct image_data *image_load_jpeg(const char *path) {
     jpeg_destroy_decompress(&cinfo);
     fclose(fp);
 
-    log_debug("Loaded JPEG image: %s (%ux%u)", expanded_path, width, height);
+    /* Honor EXIF Orientation tag BEFORE display-aware scaling so the scaler
+     * sees the final visual dimensions (e.g. a portrait phone photo with
+     * orientation=6 reports 4032x3024 in the file but is actually 3024x4032
+     * once rotated). */
+    if (exif_orientation != EXIF_ORIENT_TOP_LEFT) {
+        image_apply_exif_orientation(img, exif_orientation);
+    }
+
+    log_debug("Loaded JPEG image: %s (%ux%u)", expanded_path, img->width, img->height);
 
     return img;
 }

--- a/src/output/output.c
+++ b/src/output/output.c
@@ -10,6 +10,7 @@
 #include "neowall/image/image.h"    /* For struct image_data definition */
 #include "neowall/compositor/compositor.h"
 #include "neowall/config/config_access.h"
+#include "neowall/config/config.h"  /* config_shuffle_cycle_paths() */
 #include "neowall/constants.h"
 #include "neowall/shader/shader.h"
 #include "neowall/shader/shader_multipass.h"
@@ -211,6 +212,7 @@ struct output_state *output_create(struct neowall_state *state,
     out->config->transition = TRANSITION_NONE;
     out->config->transition_duration = 300;
     out->config->cycle = false;
+    out->config->shuffle = false;
     out->config->cycle_paths = NULL;
     out->config->cycle_count = 0;
     out->config->current_cycle_index = 0;
@@ -1055,8 +1057,33 @@ void output_cycle_wallpaper(struct output_state *output) {
     /* Move to next wallpaper/shader - protect cycle_paths access with mutex */
     pthread_mutex_lock(&output->state->state_mutex);
     size_t old_index = output->config->current_cycle_index;
-    output->config->current_cycle_index =
+    size_t next_index =
         (output->config->current_cycle_index + 1) % output->config->cycle_count;
+
+    /* End of the sequence — if shuffle is on, re-randomise so the next pass
+     * is a fresh order (issue #47). keep_first_at_zero=true pins the
+     * just-shown item at slot 0 so we don't immediately repeat it; we then
+     * advance past it by leaving next_index at the wrap (0) and bumping it. */
+    if (next_index == 0 && output->config->shuffle &&
+        output->config->cycle_paths && output->config->cycle_count > 1) {
+        /* Pin the currently-displayed item at index 0 so the shuffle keeps
+         * it there — swap it in, then shuffle [1, n). After the shuffle we
+         * step to index 1 (the first item of the freshly-randomised tail). */
+        size_t cur = output->config->current_cycle_index;
+        if (cur != 0) {
+            char *tmp = output->config->cycle_paths[0];
+            output->config->cycle_paths[0] = output->config->cycle_paths[cur];
+            output->config->cycle_paths[cur] = tmp;
+        }
+        config_shuffle_cycle_paths(output->config->cycle_paths,
+                                   output->config->cycle_count, true);
+        next_index = 1;
+        log_debug("Cycle wrap on output %s: re-shuffled %zu-entry list",
+                 output->model[0] ? output->model : "unknown",
+                 output->config->cycle_count);
+    }
+
+    output->config->current_cycle_index = next_index;
 
     /* Copy path before releasing lock to avoid use-after-free if config reloads */
     char next_path_copy[MAX_PATH_LENGTH];
@@ -1343,23 +1370,28 @@ bool output_apply_config(struct output_state *output, struct wallpaper_config *c
             }
         }
 
-        /* Restore cycle index from state file for this specific output */
-        const char *output_id = output_get_identifier(output);
-        int saved_index = restore_cycle_index_from_state(output_id);
-        if (saved_index >= 0 && saved_index < (int)output->config->cycle_count) {
-            output->config->current_cycle_index = saved_index;
-            log_info("Restored cycle position for %s: %d/%zu",
-                    output_id, saved_index, output->config->cycle_count);
+        /* Restore cycle index from state file for this specific output.
+         * Skipped under shuffle: the saved index refers to a different
+         * (previous) random permutation of the directory, so resuming at
+         * that slot would just point to an arbitrary file (issue #47). */
+        if (!output->config->shuffle) {
+            const char *output_id = output_get_identifier(output);
+            int saved_index = restore_cycle_index_from_state(output_id);
+            if (saved_index >= 0 && saved_index < (int)output->config->cycle_count) {
+                output->config->current_cycle_index = saved_index;
+                log_info("Restored cycle position for %s: %d/%zu",
+                        output_id, saved_index, output->config->cycle_count);
 
-            /* Update the initial path to use the restored index */
-            if (output->config->type == WALLPAPER_SHADER) {
-                snprintf(output->config->shader_path,
-                         sizeof(output->config->shader_path), "%s",
-                         output->config->cycle_paths[saved_index]);
-            } else {
-                snprintf(output->config->path,
-                         sizeof(output->config->path), "%s",
-                         output->config->cycle_paths[saved_index]);
+                /* Update the initial path to use the restored index */
+                if (output->config->type == WALLPAPER_SHADER) {
+                    snprintf(output->config->shader_path,
+                             sizeof(output->config->shader_path), "%s",
+                             output->config->cycle_paths[saved_index]);
+                } else {
+                    snprintf(output->config->path,
+                             sizeof(output->config->path), "%s",
+                             output->config->cycle_paths[saved_index]);
+                }
             }
         }
 


### PR DESCRIPTION
Fixes two open issues.

## #48 — JPEG EXIF orientation

Photos from phones and modern cameras encode rotation in the EXIF Orientation tag (TIFF 0x0112) rather than baked into the pixel grid. neowall was ignoring the tag, so portrait phone photos rendered sideways or upside-down.

- Save APP1 markers via `jpeg_save_markers()` before `jpeg_read_header()`.
- Parse the TIFF IFD0 for the Orientation tag (both byte orders, bounded scan, malformed EXIF treated as identity rather than failing the decode).
- Apply the matching rotate/flip/transpose transform to the RGBA buffer **before** \`image_scale_to_display\` so the scaler sees the final visual dimensions.
- All 8 EXIF orientations handled.

## #47 — \`shuffle\` config option

New per-block \`shuffle true\` option for directory cycling (works for both image and shader cycles).

- Shuffled at parse time → every monitor sharing the block sees the same order, so multi-monitor synchronised cycling keeps working.
- On wrap, the just-shown item is pinned at index 0 and the rest of the list is re-shuffled, so the daemon never settles into a fixed loop AND the same wallpaper never appears back-to-back across the wrap.
- Saved cycle-position restore is suppressed under shuffle (a previous random permutation's index is meaningless against a fresh one).
- RNG seeded lazily from \`CLOCK_MONOTONIC ^ getpid()\`.
- Documented in \`config/docs/CONFIG.md\` + commented-out example in \`config/neowall.vibe\`.

## Verification

- Builds clean with \`-Wall -Wextra -Wpedantic -Werror\`.
- All 6 tests pass on the default debug build and on \`-Db_sanitize=address,undefined\` (ASan + UBSan + LSan).