### PR TITLE
tests: add unit tests for EXIF orientation (#48) and shuffle (#47)

### DIFF
--- a/include/neowall/config/config.h
+++ b/include/neowall/config/config.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 /* Forward declarations */
 struct neowall_state;

--- a/include/neowall/image/exif.h
+++ b/include/neowall/image/exif.h
@@ -1,0 +1,46 @@
+/* EXIF Orientation parsing + transform for JPEG decode.
+ *
+ * Internal to the image module. Split out from image.c so the parser/transform
+ * can be unit-tested without dragging libjpeg, libpng, or the rest of neowall's
+ * I/O surface into the test binary. (See tests/test_image_exif.c.)
+ *
+ * Parser: walks the TIFF IFD0 in an APP1 marker payload looking for tag 0x0112
+ * (Orientation). Handles both byte orders ("MM" big-endian, "II" little).
+ * Treats malformed EXIF as "no rotation" — never fails the decode.
+ *
+ * Transform: rewrites an RGBA buffer in place (new buffer allocated, old freed)
+ * to honor one of the 8 EXIF orientation tags. Width/height in `img` are
+ * updated when the transform transposes the axes.
+ */
+#ifndef NEOWALL_IMAGE_EXIF_H
+#define NEOWALL_IMAGE_EXIF_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "neowall/image/image.h"
+
+/* EXIF Orientation tag values (TIFF/EP §4.6.4). 1 = identity. */
+enum exif_orientation {
+    EXIF_ORIENT_TOP_LEFT       = 1, /* identity */
+    EXIF_ORIENT_TOP_RIGHT      = 2, /* mirror horizontal */
+    EXIF_ORIENT_BOTTOM_RIGHT   = 3, /* rotate 180 */
+    EXIF_ORIENT_BOTTOM_LEFT    = 4, /* mirror vertical */
+    EXIF_ORIENT_LEFT_TOP       = 5, /* transpose */
+    EXIF_ORIENT_RIGHT_TOP      = 6, /* rotate 90 CW */
+    EXIF_ORIENT_RIGHT_BOTTOM   = 7, /* transverse */
+    EXIF_ORIENT_LEFT_BOTTOM    = 8, /* rotate 270 CW */
+};
+
+/* Parse an APP1 (EXIF) marker payload and return the Orientation tag value.
+ * `data` points at the bytes after the JPEG marker length field — i.e. the
+ * first 6 bytes are "Exif\0\0" followed by a TIFF header. Returns
+ * EXIF_ORIENT_TOP_LEFT (1) on any malformed input. */
+int exif_parse_orientation(const uint8_t *data, size_t len);
+
+/* Apply an EXIF orientation to an RGBA pixel buffer in place. On axis-
+ * transposing orientations (5–8) the buffer is reallocated and img->width /
+ * img->height are swapped. No-op for orientation 1 or invalid values. */
+void image_apply_exif_orientation(struct image_data *img, int orientation);
+
+#endif /* NEOWALL_IMAGE_EXIF_H */

--- a/meson.build
+++ b/meson.build
@@ -238,6 +238,7 @@ output_sources = files(
 # Config sources
 config_sources = files(
   'src/config/config.c',
+  'src/config/shuffle.c',
   'src/config/vibe.c',
 )
 
@@ -249,6 +250,7 @@ render_sources = files(
 # Image sources
 image_sources = files(
   'src/image/image.c',
+  'src/image/exif.c',
 )
 
 # Compositor abstraction layer sources
@@ -494,6 +496,26 @@ test_fft_exe = executable('test_reactive_fft',
 )
 
 test('reactive_fft', test_fft_exe)
+
+# EXIF Orientation parser + RGBA transform (issue #48). Header-light: links
+# only src/image/exif.c; no libjpeg/libpng or display server needed.
+test_exif_exe = executable('test_image_exif',
+  files('tests/test_image_exif.c', 'src/image/exif.c'),
+  include_directories: [inc_dirs, inc_dirs_build],
+  build_by_default: false,
+)
+
+test('image_exif', test_exif_exe)
+
+# Fisher-Yates shuffle for cycle paths (issue #47). Pure data; links
+# src/config/shuffle.c only.
+test_shuffle_exe = executable('test_shuffle',
+  files('tests/test_shuffle.c', 'src/config/shuffle.c'),
+  include_directories: [inc_dirs, inc_dirs_build],
+  build_by_default: false,
+)
+
+test('shuffle', test_shuffle_exe)
 
 # =============================================================================
 # Fuzzers (opt-in: -Dfuzz=true, clang only)

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -202,42 +202,8 @@ static int compare_strings(const void *a, const void *b) {
     return strcmp(str_a, str_b);
 }
 
-/* Fisher-Yates shuffle on an array of cycle path pointers (issue #47).
- *
- * Uses random() (POSIX, ~31-bit period — fine for picking a wallpaper order),
- * seeded once per process from CLOCK_MONOTONIC + getpid() so two daemons started
- * in the same second don't pick the same sequence. The seed is intentionally
- * lazy: a shader/image cycle that's never built never touches the RNG.
- *
- * `keep_first_at_zero` is the "re-shuffle on wrap" mode: it shuffles only
- * indices [1, n) so the wallpaper that was just shown stays at position 0,
- * preventing the same image appearing twice in a row across a wrap. */
-void config_shuffle_cycle_paths(char **paths, size_t n, bool keep_first_at_zero) {
-    if (!paths || n < 2) return;
-
-    static bool seeded = false;
-    if (!seeded) {
-        struct timespec ts;
-        clock_gettime(CLOCK_MONOTONIC, &ts);
-        unsigned int seed = (unsigned int)ts.tv_nsec
-                          ^ (unsigned int)(ts.tv_sec << 16)
-                          ^ (unsigned int)getpid();
-        srandom(seed);
-        seeded = true;
-    }
-
-    size_t start = keep_first_at_zero ? 1 : 0;
-    if (n - start < 2) return;
-
-    /* Standard Fisher-Yates: walk from the end down, swap with a random
-     * earlier (or same) slot. Uniform if random() is uniform on [0, RAND_MAX]. */
-    for (size_t i = n - 1; i > start; i--) {
-        size_t j = start + (size_t)(random() % (long)(i - start + 1));
-        char *tmp = paths[i];
-        paths[i] = paths[j];
-        paths[j] = tmp;
-    }
-}
+/* Fisher-Yates shuffle on cycle path arrays (issue #47) lives in shuffle.c
+ * so it can be unit-tested without the rest of this TU's heavy deps. */
 
 /* ============================================================================
  * Directory Loading Functions

--- a/src/config/shuffle.c
+++ b/src/config/shuffle.c
@@ -1,0 +1,49 @@
+/* Fisher-Yates shuffle for wallpaper cycle paths (issue #47).
+ *
+ * Split out of config.c so the shuffle logic can be unit-tested without
+ * pulling in the vibe parser, compositor, shader, and image modules.
+ *
+ * Uses random() (POSIX, ~31-bit period — fine for picking a wallpaper order),
+ * seeded once per process from CLOCK_MONOTONIC + getpid() so two daemons
+ * started in the same second don't pick the same sequence. The seed is lazy:
+ * a cycle that's never built never touches the RNG.
+ *
+ * `keep_first_at_zero` is the "re-shuffle on wrap" mode: it shuffles only
+ * indices [1, n) so the wallpaper that was just shown stays at position 0,
+ * preventing the same image appearing twice in a row across a wrap. */
+#define _DEFAULT_SOURCE
+#define _BSD_SOURCE
+
+#include "neowall/config/config.h"
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+void config_shuffle_cycle_paths(char **paths, size_t n, bool keep_first_at_zero) {
+    if (!paths || n < 2) return;
+
+    static bool seeded = false;
+    if (!seeded) {
+        struct timespec ts;
+        clock_gettime(CLOCK_MONOTONIC, &ts);
+        unsigned int seed = (unsigned int)ts.tv_nsec
+                          ^ (unsigned int)(ts.tv_sec << 16)
+                          ^ (unsigned int)getpid();
+        srandom(seed);
+        seeded = true;
+    }
+
+    size_t start = keep_first_at_zero ? 1 : 0;
+    if (n - start < 2) return;
+
+    /* Standard Fisher-Yates: walk from the end down, swap with a random
+     * earlier (or same) slot. Uniform if random() is uniform on [0, RAND_MAX]. */
+    for (size_t i = n - 1; i > start; i--) {
+        size_t j = start + (size_t)(random() % (long)(i - start + 1));
+        char *tmp = paths[i];
+        paths[i] = paths[j];
+        paths[j] = tmp;
+    }
+}

--- a/src/image/exif.c
+++ b/src/image/exif.c
@@ -1,0 +1,113 @@
+/* EXIF Orientation parser + RGBA-buffer transform.
+ *
+ * Split out of image.c so it can be unit-tested without libjpeg/libpng deps.
+ * Logging deliberately stubbed to fprintf so the test binary doesn't need to
+ * pull in the rest of neowall just to print one warn line on alloc failure. */
+#include "neowall/image/exif.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* TIFF byte-order helpers. `be` selects big-endian ("MM"). */
+static uint16_t exif_u16(const uint8_t *p, int be) {
+    return be ? (uint16_t)((p[0] << 8) | p[1])
+              : (uint16_t)((p[1] << 8) | p[0]);
+}
+static uint32_t exif_u32(const uint8_t *p, int be) {
+    return be ? ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) | ((uint32_t)p[2] << 8) | p[3]
+              : ((uint32_t)p[3] << 24) | ((uint32_t)p[2] << 16) | ((uint32_t)p[1] << 8) | p[0];
+}
+
+int exif_parse_orientation(const uint8_t *data, size_t len) {
+    if (!data) return EXIF_ORIENT_TOP_LEFT;
+    /* APP1 EXIF signature ("Exif\0\0", 6 B) + minimal TIFF header (8 B). */
+    if (len < 6 + 8) return EXIF_ORIENT_TOP_LEFT;
+    if (memcmp(data, "Exif\0\0", 6) != 0) return EXIF_ORIENT_TOP_LEFT;
+
+    const uint8_t *tiff = data + 6;
+    size_t tiff_len = len - 6;
+
+    int be;
+    if (tiff[0] == 'M' && tiff[1] == 'M') be = 1;
+    else if (tiff[0] == 'I' && tiff[1] == 'I') be = 0;
+    else return EXIF_ORIENT_TOP_LEFT;
+
+    if (exif_u16(tiff + 2, be) != 0x002A) return EXIF_ORIENT_TOP_LEFT;
+
+    uint32_t ifd0_off = exif_u32(tiff + 4, be);
+    if ((size_t)ifd0_off + 2 > tiff_len) return EXIF_ORIENT_TOP_LEFT;
+
+    uint16_t n_entries = exif_u16(tiff + ifd0_off, be);
+    /* Each IFD entry is 12 B. Cap to dodge pathological files. */
+    if (n_entries > 1024) return EXIF_ORIENT_TOP_LEFT;
+    if ((size_t)ifd0_off + 2 + (size_t)n_entries * 12 > tiff_len) return EXIF_ORIENT_TOP_LEFT;
+
+    for (uint16_t i = 0; i < n_entries; i++) {
+        const uint8_t *e = tiff + ifd0_off + 2 + (size_t)i * 12;
+        uint16_t tag  = exif_u16(e, be);
+        uint16_t type = exif_u16(e + 2, be);
+        uint32_t cnt  = exif_u32(e + 4, be);
+        if (tag == 0x0112 /* Orientation */ && type == 3 /* SHORT */ && cnt >= 1) {
+            /* SHORT inline value lives in the first 2 B of the value field
+             * (offset +8); endian handling is the same as any other u16 read. */
+            uint16_t v = exif_u16(e + 8, be);
+            if (v >= 1 && v <= 8) return (int)v;
+            return EXIF_ORIENT_TOP_LEFT;
+        }
+    }
+    return EXIF_ORIENT_TOP_LEFT;
+}
+
+void image_apply_exif_orientation(struct image_data *img, int orientation) {
+    if (!img || !img->pixels || orientation == EXIF_ORIENT_TOP_LEFT) return;
+    if (orientation < 1 || orientation > 8) return;
+
+    const uint32_t w = img->width;
+    const uint32_t h = img->height;
+    const int transpose = (orientation >= 5);
+    const uint32_t nw = transpose ? h : w;
+    const uint32_t nh = transpose ? w : h;
+
+    /* Overflow guard. The product nw*nh*4 must fit in size_t. On 64-bit
+     * `(size_t)nw*4 > SIZE_MAX/nh` covers everything we'd reach in practice;
+     * the wider bound was already checked once in the caller (pre-rotation)
+     * but transpose changes which axis is the long one, so re-check here. */
+    if (nh != 0 && (size_t)nw * 4 > SIZE_MAX / nh) return;
+    uint8_t *dst = malloc((size_t)nw * nh * 4);
+    if (!dst) {
+        fprintf(stderr, "EXIF orient: alloc failed, leaving image as-is\n");
+        return;
+    }
+
+    const uint8_t *src = img->pixels;
+    /* Walk the source linearly; compute the destination (dx,dy) per the EXIF
+     * transform table. Cache-friendly on the read side, scatter on the write. */
+    for (uint32_t sy = 0; sy < h; sy++) {
+        for (uint32_t sx = 0; sx < w; sx++) {
+            uint32_t dx = 0, dy = 0;
+            switch (orientation) {
+                case EXIF_ORIENT_TOP_RIGHT:    dx = w - 1 - sx; dy = sy;            break;
+                case EXIF_ORIENT_BOTTOM_RIGHT: dx = w - 1 - sx; dy = h - 1 - sy;    break;
+                case EXIF_ORIENT_BOTTOM_LEFT:  dx = sx;         dy = h - 1 - sy;    break;
+                case EXIF_ORIENT_LEFT_TOP:     dx = sy;         dy = sx;            break;
+                case EXIF_ORIENT_RIGHT_TOP:    dx = h - 1 - sy; dy = sx;            break;
+                case EXIF_ORIENT_RIGHT_BOTTOM: dx = h - 1 - sy; dy = w - 1 - sx;    break;
+                case EXIF_ORIENT_LEFT_BOTTOM:  dx = sy;         dy = w - 1 - sx;    break;
+                default:                       dx = sx;         dy = sy;            break;
+            }
+            size_t s = ((size_t)sy * w + sx) * 4;
+            size_t d = ((size_t)dy * nw + dx) * 4;
+            dst[d + 0] = src[s + 0];
+            dst[d + 1] = src[s + 1];
+            dst[d + 2] = src[s + 2];
+            dst[d + 3] = src[s + 3];
+        }
+    }
+
+    free(img->pixels);
+    img->pixels = dst;
+    img->width  = nw;
+    img->height = nh;
+}

--- a/src/image/image.c
+++ b/src/image/image.c
@@ -7,6 +7,7 @@
 #include <png.h>
 #include <jpeglib.h>
 #include "neowall/image/image.h"
+#include "neowall/image/exif.h"
 #include "neowall/neowall.h"
 #include "neowall/constants.h"
 
@@ -248,135 +249,6 @@ static void jpeg_error_exit(j_common_ptr cinfo) {
     struct jpeg_error_mgr_ext *err = (struct jpeg_error_mgr_ext *)cinfo->err;
     (*cinfo->err->format_message)(cinfo, err->error_msg);
     longjmp(err->setjmp_buffer, 1);
-}
-
-/* EXIF orientation values per TIFF/EP. 1 = identity. */
-enum exif_orientation {
-    EXIF_ORIENT_TOP_LEFT       = 1, /* identity */
-    EXIF_ORIENT_TOP_RIGHT      = 2, /* mirror horizontal */
-    EXIF_ORIENT_BOTTOM_RIGHT   = 3, /* rotate 180 */
-    EXIF_ORIENT_BOTTOM_LEFT    = 4, /* mirror vertical */
-    EXIF_ORIENT_LEFT_TOP       = 5, /* mirror horizontal + rotate 270 CW */
-    EXIF_ORIENT_RIGHT_TOP      = 6, /* rotate 90 CW */
-    EXIF_ORIENT_RIGHT_BOTTOM   = 7, /* mirror horizontal + rotate 90 CW */
-    EXIF_ORIENT_LEFT_BOTTOM    = 8, /* rotate 270 CW (== 90 CCW) */
-};
-
-/* Little helper: read u16/u32 honoring TIFF byte order. */
-static uint16_t exif_u16(const uint8_t *p, bool be) {
-    return be ? (uint16_t)((p[0] << 8) | p[1])
-              : (uint16_t)((p[1] << 8) | p[0]);
-}
-static uint32_t exif_u32(const uint8_t *p, bool be) {
-    return be ? ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) | ((uint32_t)p[2] << 8) | p[3]
-              : ((uint32_t)p[3] << 24) | ((uint32_t)p[2] << 16) | ((uint32_t)p[1] << 8) | p[0];
-}
-
-/* Parse an APP1 (EXIF) marker payload and return the Orientation tag value.
- * `data` is the bytes AFTER the marker length field (i.e. starting with the
- * "Exif\0\0" signature). Returns 1 (identity) if anything looks off — we treat
- * malformed EXIF as "no rotation" rather than failing the whole decode. */
-static int exif_parse_orientation(const uint8_t *data, size_t len) {
-    /* APP1 EXIF signature: "Exif\0\0" (6 bytes) followed by the TIFF header. */
-    if (len < 6 + 8) return EXIF_ORIENT_TOP_LEFT;
-    if (memcmp(data, "Exif\0\0", 6) != 0) return EXIF_ORIENT_TOP_LEFT;
-
-    const uint8_t *tiff = data + 6;
-    size_t tiff_len = len - 6;
-
-    bool be;
-    if (tiff[0] == 'M' && tiff[1] == 'M') be = true;
-    else if (tiff[0] == 'I' && tiff[1] == 'I') be = false;
-    else return EXIF_ORIENT_TOP_LEFT;
-
-    if (exif_u16(tiff + 2, be) != 0x002A) return EXIF_ORIENT_TOP_LEFT;
-
-    uint32_t ifd0_off = exif_u32(tiff + 4, be);
-    if (ifd0_off + 2 > tiff_len) return EXIF_ORIENT_TOP_LEFT;
-
-    uint16_t n_entries = exif_u16(tiff + ifd0_off, be);
-    /* Each IFD entry is 12 bytes. Cap at a sane bound to avoid pathological files. */
-    if (n_entries > 1024) return EXIF_ORIENT_TOP_LEFT;
-    if ((size_t)ifd0_off + 2 + (size_t)n_entries * 12 > tiff_len) return EXIF_ORIENT_TOP_LEFT;
-
-    for (uint16_t i = 0; i < n_entries; i++) {
-        const uint8_t *e = tiff + ifd0_off + 2 + (size_t)i * 12;
-        uint16_t tag  = exif_u16(e, be);
-        uint16_t type = exif_u16(e + 2, be);
-        uint32_t cnt  = exif_u32(e + 4, be);
-        if (tag == 0x0112 /* Orientation */ && type == 3 /* SHORT */ && cnt >= 1) {
-            /* SHORT inline value sits in the first 2 bytes of the value field;
-             * for big-endian that's e+8, little-endian also e+8 (low byte first). */
-            uint16_t v = exif_u16(e + 8, be);
-            if (v >= 1 && v <= 8) return (int)v;
-            return EXIF_ORIENT_TOP_LEFT;
-        }
-    }
-    return EXIF_ORIENT_TOP_LEFT;
-}
-
-/* Apply an EXIF orientation to an RGBA pixel buffer in place (new buffer
- * allocated, old one freed). Width/height in `img` are updated when the
- * orientation transposes the axes. No-op for orientation 1. */
-static void image_apply_exif_orientation(struct image_data *img, int orientation) {
-    if (!img || !img->pixels || orientation == EXIF_ORIENT_TOP_LEFT) {
-        return;
-    }
-    if (orientation < 1 || orientation > 8) {
-        return;
-    }
-
-    const uint32_t w = img->width;
-    const uint32_t h = img->height;
-    const bool transpose = (orientation >= 5);
-    const uint32_t nw = transpose ? h : w;
-    const uint32_t nh = transpose ? w : h;
-
-    /* Overflow guard. The product nw*nh*4 must fit in size_t (already validated
-     * pre-rotation in the loader, but transpose changes which axis is the long
-     * one, so re-check). On 64-bit (size_t == uint64_t) `nw > SIZE_MAX/4` is
-     * tautologically false for uint32_t — only the nh-multiplied bound matters. */
-    if (nh != 0 && (size_t)nw * 4 > SIZE_MAX / nh) {
-        return;
-    }
-    uint8_t *dst = malloc((size_t)nw * nh * 4);
-    if (!dst) {
-        log_warn("EXIF orient: alloc failed, leaving image as-is");
-        return;
-    }
-
-    const uint8_t *src = img->pixels;
-    /* For each (sx,sy) source pixel, compute its destination (dx,dy) per the
-     * EXIF transform, then copy the 4 RGBA bytes. Walking the source linearly
-     * keeps cache behaviour predictable on the hot read side. */
-    for (uint32_t sy = 0; sy < h; sy++) {
-        for (uint32_t sx = 0; sx < w; sx++) {
-            uint32_t dx = 0, dy = 0;
-            switch (orientation) {
-                case EXIF_ORIENT_TOP_RIGHT:    dx = w - 1 - sx; dy = sy;            break;
-                case EXIF_ORIENT_BOTTOM_RIGHT: dx = w - 1 - sx; dy = h - 1 - sy;    break;
-                case EXIF_ORIENT_BOTTOM_LEFT:  dx = sx;         dy = h - 1 - sy;    break;
-                case EXIF_ORIENT_LEFT_TOP:     dx = sy;         dy = sx;            break;
-                case EXIF_ORIENT_RIGHT_TOP:    dx = h - 1 - sy; dy = sx;            break;
-                case EXIF_ORIENT_RIGHT_BOTTOM: dx = h - 1 - sy; dy = w - 1 - sx;    break;
-                case EXIF_ORIENT_LEFT_BOTTOM:  dx = sy;         dy = w - 1 - sx;    break;
-                default:                       dx = sx;         dy = sy;            break;
-            }
-            size_t s = ((size_t)sy * w + sx) * 4;
-            size_t d = ((size_t)dy * nw + dx) * 4;
-            dst[d + 0] = src[s + 0];
-            dst[d + 1] = src[s + 1];
-            dst[d + 2] = src[s + 2];
-            dst[d + 3] = src[s + 3];
-        }
-    }
-
-    free(img->pixels);
-    img->pixels = dst;
-    img->width  = nw;
-    img->height = nh;
-    log_debug("Applied EXIF orientation %d (%ux%u -> %ux%u)",
-              orientation, w, h, nw, nh);
 }
 
 /* Load JPEG image */

--- a/tests/test_image_exif.c
+++ b/tests/test_image_exif.c
@@ -1,0 +1,297 @@
+/* Unit tests for the EXIF Orientation parser + RGBA transform (issue #48).
+ *
+ * Headless: no libjpeg, no display server. We hand-craft minimal APP1 EXIF
+ * blobs (Exif\0\0 + TIFF header + 1 IFD entry) in both byte orders, plus a
+ * handful of malformed payloads that must safely fall back to identity. We
+ * also paint a 3x2 (or 2x3) RGBA "letter" buffer for each of the 8 transforms
+ * and verify every destination pixel lands at the EXIF-spec coordinate.
+ */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "neowall/image/exif.h"
+#include "neowall/image/image.h"
+
+static int failures = 0;
+static int checks = 0;
+
+#define CHECK(cond)                                                            \
+    do {                                                                       \
+        checks++;                                                              \
+        if (!(cond)) {                                                         \
+            failures++;                                                        \
+            fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);    \
+        }                                                                      \
+    } while (0)
+
+/* Build a minimal EXIF APP1 payload with exactly one IFD0 entry: the
+ * Orientation tag with the given value. `be` selects byte order. Layout:
+ *   [0..5]   "Exif\0\0"
+ *   [6..7]   "MM" or "II"
+ *   [8..9]   0x002A
+ *   [10..13] IFD0 offset (= 8, immediately after the TIFF header)
+ *   [14..15] entry count (1)
+ *   [16..27] IFD entry: tag=0x0112 type=SHORT count=1 value=<orientation>
+ *   [28..29] next-IFD offset (0)
+ * Returns total length written. Caller passes a buffer of >= 32 B.
+ */
+static size_t build_exif_blob(uint8_t *buf, int be, uint16_t orientation) {
+    memcpy(buf, "Exif\0\0", 6);
+    if (be) { buf[6] = 'M'; buf[7] = 'M'; } else { buf[6] = 'I'; buf[7] = 'I'; }
+
+    /* TIFF magic 0x002A */
+    if (be) { buf[8] = 0x00; buf[9] = 0x2A; } else { buf[8] = 0x2A; buf[9] = 0x00; }
+
+    /* IFD0 offset = 8 (relative to TIFF header start, i.e. buf+6) */
+    if (be) { buf[10] = 0; buf[11] = 0; buf[12] = 0; buf[13] = 8; }
+    else    { buf[10] = 8; buf[11] = 0; buf[12] = 0; buf[13] = 0; }
+
+    /* IFD entry count = 1 (located at TIFF+8 = buf+14) */
+    if (be) { buf[14] = 0; buf[15] = 1; } else { buf[14] = 1; buf[15] = 0; }
+
+    /* Entry: tag=0x0112 (Orientation), type=3 (SHORT), count=1, value=orientation */
+    uint8_t *e = buf + 16;
+    if (be) {
+        e[0] = 0x01; e[1] = 0x12;                       /* tag */
+        e[2] = 0x00; e[3] = 0x03;                       /* type */
+        e[4] = 0; e[5] = 0; e[6] = 0; e[7] = 1;         /* count */
+        e[8] = (uint8_t)(orientation >> 8);
+        e[9] = (uint8_t)(orientation & 0xFF);
+        e[10] = 0; e[11] = 0;                           /* value padding */
+    } else {
+        e[0] = 0x12; e[1] = 0x01;
+        e[2] = 0x03; e[3] = 0x00;
+        e[4] = 1; e[5] = 0; e[6] = 0; e[7] = 0;
+        e[8] = (uint8_t)(orientation & 0xFF);
+        e[9] = (uint8_t)(orientation >> 8);
+        e[10] = 0; e[11] = 0;
+    }
+
+    /* Next-IFD offset = 0 (no IFD1) */
+    buf[28] = 0; buf[29] = 0; buf[30] = 0; buf[31] = 0;
+    return 32;
+}
+
+static void test_parser_well_formed_be(void) {
+    uint8_t buf[64];
+    for (uint16_t o = 1; o <= 8; o++) {
+        size_t n = build_exif_blob(buf, 1, o);
+        int got = exif_parse_orientation(buf, n);
+        CHECK(got == (int)o);
+    }
+}
+
+static void test_parser_well_formed_le(void) {
+    uint8_t buf[64];
+    for (uint16_t o = 1; o <= 8; o++) {
+        size_t n = build_exif_blob(buf, 0, o);
+        int got = exif_parse_orientation(buf, n);
+        CHECK(got == (int)o);
+    }
+}
+
+static void test_parser_no_orientation_tag(void) {
+    /* Same skeleton but the IFD entry is some other tag (ImageWidth = 0x0100). */
+    uint8_t buf[64];
+    size_t n = build_exif_blob(buf, 1, 6);
+    buf[16] = 0x01; buf[17] = 0x00;  /* tag = ImageWidth, not Orientation */
+    int got = exif_parse_orientation(buf, n);
+    CHECK(got == EXIF_ORIENT_TOP_LEFT);
+}
+
+static void test_parser_malformed(void) {
+    /* NULL / zero-length / too-short / bad signature / bad byte-order /
+     * bad TIFF magic / out-of-range orientation value / out-of-bounds IFD
+     * offset / absurd entry count — all must return identity, never crash. */
+    CHECK(exif_parse_orientation(NULL, 0) == EXIF_ORIENT_TOP_LEFT);
+    CHECK(exif_parse_orientation((const uint8_t *)"", 0) == EXIF_ORIENT_TOP_LEFT);
+
+    uint8_t tiny[8] = {'E','x','i','f',0,0,'M','M'};
+    CHECK(exif_parse_orientation(tiny, sizeof(tiny)) == EXIF_ORIENT_TOP_LEFT);
+
+    uint8_t buf[64];
+    size_t n;
+
+    /* Bad signature */
+    n = build_exif_blob(buf, 1, 6);
+    buf[0] = 'X';
+    CHECK(exif_parse_orientation(buf, n) == EXIF_ORIENT_TOP_LEFT);
+
+    /* Bad byte-order tag */
+    n = build_exif_blob(buf, 1, 6);
+    buf[6] = 'X'; buf[7] = 'X';
+    CHECK(exif_parse_orientation(buf, n) == EXIF_ORIENT_TOP_LEFT);
+
+    /* Bad TIFF magic */
+    n = build_exif_blob(buf, 1, 6);
+    buf[8] = 0xFF; buf[9] = 0xFF;
+    CHECK(exif_parse_orientation(buf, n) == EXIF_ORIENT_TOP_LEFT);
+
+    /* Out-of-bounds IFD offset */
+    n = build_exif_blob(buf, 1, 6);
+    buf[10] = 0xFF; buf[11] = 0xFF; buf[12] = 0xFF; buf[13] = 0xFF;
+    CHECK(exif_parse_orientation(buf, n) == EXIF_ORIENT_TOP_LEFT);
+
+    /* Absurd entry count (> 1024 cap) */
+    n = build_exif_blob(buf, 1, 6);
+    buf[14] = 0xFF; buf[15] = 0xFF;
+    CHECK(exif_parse_orientation(buf, n) == EXIF_ORIENT_TOP_LEFT);
+
+    /* Orientation value out of range [1..8] */
+    n = build_exif_blob(buf, 1, 99);
+    CHECK(exif_parse_orientation(buf, n) == EXIF_ORIENT_TOP_LEFT);
+}
+
+/* ---------- transform tests ---------- */
+
+/* Paint a w×h RGBA buffer where each pixel's R channel encodes (y*w + x),
+ * G encodes x, B encodes y. Alpha = 0xFF. Lets us read back any pixel after
+ * a transform and recover its original source coordinate uniquely. */
+static struct image_data *make_test_img(uint32_t w, uint32_t h) {
+    struct image_data *img = calloc(1, sizeof(*img));
+    img->width = w;
+    img->height = h;
+    img->channels = 4;
+    img->format = FORMAT_JPEG;
+    img->pixels = malloc((size_t)w * h * 4);
+    for (uint32_t y = 0; y < h; y++) {
+        for (uint32_t x = 0; x < w; x++) {
+            size_t i = ((size_t)y * w + x) * 4;
+            img->pixels[i + 0] = (uint8_t)(y * w + x);
+            img->pixels[i + 1] = (uint8_t)x;
+            img->pixels[i + 2] = (uint8_t)y;
+            img->pixels[i + 3] = 0xFF;
+        }
+    }
+    return img;
+}
+
+static void free_test_img(struct image_data *img) {
+    if (!img) return;
+    free(img->pixels);
+    free(img);
+}
+
+static void px_at(const struct image_data *img, uint32_t x, uint32_t y,
+                  uint8_t *r, uint8_t *g, uint8_t *b) {
+    size_t i = ((size_t)y * img->width + x) * 4;
+    *r = img->pixels[i + 0];
+    *g = img->pixels[i + 1];
+    *b = img->pixels[i + 2];
+}
+
+/* Verify: for the given orientation, the pixel that started at source
+ * coordinates (sx, sy) in a w×h buffer ends up at (dx, dy) in the (nw×nh)
+ * destination, matching the EXIF spec. */
+static void check_pixel(int orientation,
+                        uint32_t w, uint32_t h,
+                        uint32_t sx, uint32_t sy,
+                        uint32_t dx, uint32_t dy)
+{
+    struct image_data *img = make_test_img(w, h);
+    image_apply_exif_orientation(img, orientation);
+
+    /* Width/height transpose for orientations 5–8. */
+    uint32_t nw = (orientation >= 5) ? h : w;
+    uint32_t nh = (orientation >= 5) ? w : h;
+    CHECK(img->width == nw);
+    CHECK(img->height == nh);
+
+    uint8_t r, g, b;
+    px_at(img, dx, dy, &r, &g, &b);
+    CHECK(g == (uint8_t)sx);  /* G channel was source x */
+    CHECK(b == (uint8_t)sy);  /* B channel was source y */
+
+    free_test_img(img);
+}
+
+static void test_transform_identity(void) {
+    /* Orientation 1 = no-op: (sx,sy) → (sx,sy). */
+    check_pixel(EXIF_ORIENT_TOP_LEFT, 3, 2, 0, 0, 0, 0);
+    check_pixel(EXIF_ORIENT_TOP_LEFT, 3, 2, 2, 1, 2, 1);
+}
+
+static void test_transform_mirror_h(void) {
+    /* Orientation 2 = mirror horizontal: (sx,sy) → (w-1-sx, sy). */
+    check_pixel(EXIF_ORIENT_TOP_RIGHT, 3, 2, 0, 0, 2, 0);
+    check_pixel(EXIF_ORIENT_TOP_RIGHT, 3, 2, 2, 1, 0, 1);
+}
+
+static void test_transform_rotate_180(void) {
+    /* Orientation 3 = rotate 180: (sx,sy) → (w-1-sx, h-1-sy). */
+    check_pixel(EXIF_ORIENT_BOTTOM_RIGHT, 3, 2, 0, 0, 2, 1);
+    check_pixel(EXIF_ORIENT_BOTTOM_RIGHT, 3, 2, 2, 1, 0, 0);
+}
+
+static void test_transform_mirror_v(void) {
+    /* Orientation 4 = mirror vertical: (sx,sy) → (sx, h-1-sy). */
+    check_pixel(EXIF_ORIENT_BOTTOM_LEFT, 3, 2, 0, 0, 0, 1);
+    check_pixel(EXIF_ORIENT_BOTTOM_LEFT, 3, 2, 2, 1, 2, 0);
+}
+
+static void test_transform_transpose(void) {
+    /* Orientation 5 = transpose (main diagonal): (sx,sy) → (sy, sx). */
+    check_pixel(EXIF_ORIENT_LEFT_TOP, 3, 2, 0, 0, 0, 0);
+    check_pixel(EXIF_ORIENT_LEFT_TOP, 3, 2, 2, 1, 1, 2);
+}
+
+static void test_transform_rotate_90_cw(void) {
+    /* Orientation 6 = rotate 90 CW: (sx,sy) → (h-1-sy, sx). The portrait-
+     * phone-photo case — this is the headline bug from issue #48. */
+    check_pixel(EXIF_ORIENT_RIGHT_TOP, 3, 2, 0, 0, 1, 0);
+    check_pixel(EXIF_ORIENT_RIGHT_TOP, 3, 2, 2, 1, 0, 2);
+}
+
+static void test_transform_transverse(void) {
+    /* Orientation 7 = transverse (anti-diagonal): (sx,sy) → (h-1-sy, w-1-sx). */
+    check_pixel(EXIF_ORIENT_RIGHT_BOTTOM, 3, 2, 0, 0, 1, 2);
+    check_pixel(EXIF_ORIENT_RIGHT_BOTTOM, 3, 2, 2, 1, 0, 0);
+}
+
+static void test_transform_rotate_270_cw(void) {
+    /* Orientation 8 = rotate 270 CW / 90 CCW: (sx,sy) → (sy, w-1-sx). */
+    check_pixel(EXIF_ORIENT_LEFT_BOTTOM, 3, 2, 0, 0, 0, 2);
+    check_pixel(EXIF_ORIENT_LEFT_BOTTOM, 3, 2, 2, 1, 1, 0);
+}
+
+static void test_transform_noop_safety(void) {
+    /* Out-of-range orientation must NOT touch the buffer. */
+    struct image_data *img = make_test_img(2, 2);
+    uint8_t *old_pixels = img->pixels;
+    image_apply_exif_orientation(img, 99);
+    CHECK(img->pixels == old_pixels);
+    CHECK(img->width == 2 && img->height == 2);
+    free_test_img(img);
+
+    /* NULL img / NULL pixels = no crash. */
+    image_apply_exif_orientation(NULL, 6);
+    struct image_data empty = {0};
+    image_apply_exif_orientation(&empty, 6);  /* pixels==NULL */
+    CHECK(1);  /* survived */
+}
+
+int main(void) {
+    test_parser_well_formed_be();
+    test_parser_well_formed_le();
+    test_parser_no_orientation_tag();
+    test_parser_malformed();
+
+    test_transform_identity();
+    test_transform_mirror_h();
+    test_transform_rotate_180();
+    test_transform_mirror_v();
+    test_transform_transpose();
+    test_transform_rotate_90_cw();
+    test_transform_transverse();
+    test_transform_rotate_270_cw();
+    test_transform_noop_safety();
+
+    if (failures == 0) {
+        printf("ok - %d checks passed\n", checks);
+        return 0;
+    }
+    fprintf(stderr, "not ok - %d/%d checks failed\n", failures, checks);
+    return 1;
+}

--- a/tests/test_shuffle.c
+++ b/tests/test_shuffle.c
@@ -1,0 +1,134 @@
+/* Unit tests for config_shuffle_cycle_paths (issue #47).
+ *
+ * Pure-data test: hands the shuffler arrays of unique string pointers, then
+ * asserts the multiset is preserved (it's a permutation), that the result
+ * differs from sorted input often enough to be plausibly random, and that
+ * keep_first_at_zero pins slot 0. Covers degenerate sizes too.
+ *
+ * Note: the production shuffler seeds itself lazily from CLOCK_MONOTONIC ^
+ * getpid() — the seed is fixed for the lifetime of the test process. That's
+ * fine: we don't assert any particular permutation, only invariants.
+ */
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "neowall/config/config.h"
+
+static int failures = 0;
+static int checks = 0;
+
+#define CHECK(cond)                                                            \
+    do {                                                                       \
+        checks++;                                                              \
+        if (!(cond)) {                                                         \
+            failures++;                                                        \
+            fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);    \
+        }                                                                      \
+    } while (0)
+
+#define N 32
+
+static void fill(char **paths, char (*storage)[16], int n) {
+    for (int i = 0; i < n; i++) {
+        snprintf(storage[i], 16, "item-%02d", i);
+        paths[i] = storage[i];
+    }
+}
+
+/* Verify `paths` is a permutation of the n distinct strings in `storage`. */
+static bool is_permutation(char **paths, char (*storage)[16], int n) {
+    bool *seen = calloc((size_t)n, sizeof(bool));
+    if (!seen) return false;
+    bool ok = true;
+    for (int i = 0; i < n; i++) {
+        int idx = -1;
+        for (int j = 0; j < n; j++) {
+            if (paths[i] == storage[j]) { idx = j; break; }
+        }
+        if (idx < 0 || seen[idx]) { ok = false; break; }
+        seen[idx] = true;
+    }
+    free(seen);
+    return ok;
+}
+
+static void test_degenerate(void) {
+    /* n < 2 must be a no-op (and definitely not crash). */
+    char *one[] = { "alpha" };
+    config_shuffle_cycle_paths(one, 1, false);
+    CHECK(strcmp(one[0], "alpha") == 0);
+
+    config_shuffle_cycle_paths(NULL, 5, false);  /* NULL paths */
+    config_shuffle_cycle_paths(one, 0, false);   /* zero len */
+    CHECK(1);  /* survived */
+}
+
+static void test_permutation_full(void) {
+    char storage[N][16];
+    char *paths[N];
+    fill(paths, storage, N);
+
+    config_shuffle_cycle_paths(paths, N, false);
+    CHECK(is_permutation(paths, storage, N));
+}
+
+static void test_keep_first_pins_slot_zero(void) {
+    char storage[N][16];
+    char *paths[N];
+    fill(paths, storage, N);
+
+    char *pinned = paths[0];
+    config_shuffle_cycle_paths(paths, N, true);
+
+    CHECK(paths[0] == pinned);
+    CHECK(is_permutation(paths, storage, N));
+}
+
+static void test_keep_first_n_eq_2(void) {
+    /* n == 2 with keep_first_at_zero: only paths[1..] is shuffleable, which
+     * is a single element. The function must early-return without touching
+     * either slot. */
+    char *paths[2] = { "a", "b" };
+    config_shuffle_cycle_paths(paths, 2, true);
+    CHECK(strcmp(paths[0], "a") == 0);
+    CHECK(strcmp(paths[1], "b") == 0);
+}
+
+/* Run many shuffles and confirm at least ONE of them differs from the sorted
+ * input. With N=32 and a real PRNG the probability all 64 runs land on the
+ * identity permutation is ≈ (1/32!)^64 — astronomically below false-flake
+ * thresholds. If this fires, the RNG is broken or the shuffle isn't running. */
+static void test_actually_shuffles(void) {
+    char storage[N][16];
+    char *paths[N];
+    int changed_runs = 0;
+
+    for (int run = 0; run < 64; run++) {
+        fill(paths, storage, N);
+        config_shuffle_cycle_paths(paths, N, false);
+        for (int i = 0; i < N; i++) {
+            if (paths[i] != storage[i]) { changed_runs++; break; }
+        }
+    }
+    CHECK(changed_runs > 0);
+    /* And for a sanity check the OPPOSITE: with N=32 the chance every run
+     * happens to leave even one fixed point... no, fixed points are common,
+     * skip. The "at least one differs" check above is the load-bearing one. */
+}
+
+int main(void) {
+    test_degenerate();
+    test_permutation_full();
+    test_keep_first_pins_slot_zero();
+    test_keep_first_n_eq_2();
+    test_actually_shuffles();
+
+    if (failures == 0) {
+        printf("ok - %d checks passed\n", checks);
+        return 0;
+    }
+    fprintf(stderr, "not ok - %d/%d checks failed\n", failures, checks);
+    return 1;
+}


### PR DESCRIPTION
Adds headless unit tests for the two fixes merged via #49 (commit 656b8e7). The test commit was pushed to the branch *after* the squash merge of #49 captured it, so it never made it onto main. This PR brings it across.

## What's tested

**EXIF (`tests/test_image_exif.c`)** — 4 parser tests (BE/LE/no-tag/malformed×7) + 9 transform tests (all 8 EXIF orientations + safety/NULL/out-of-range). Hand-crafts minimal TIFF APP1 blobs; uses an (R=index, G=x, B=y) probe buffer to verify destination coordinates per-orientation against the EXIF spec.

**Shuffle (`tests/test_shuffle.c`)** — degenerate cases (n<2, NULL, n=2 + keep_first), permutation invariant, slot-0 pinning under `keep_first_at_zero`, and a 64-run "actually shuffles" check.

## Refactor for testability

Extracted the EXIF parser + transform into `src/image/exif.c` + `include/neowall/image/exif.h` (was `static` inside `image.c`), and `config_shuffle_cycle_paths` into `src/config/shuffle.c` (was inside `config.c`). The test binaries link only the small TUs they exercise — no libjpeg/libpng/vibe-parser pulled in.

## Verification

```
9/9 tests pass under both build/ and build-asan/ (ASan + UBSan + LSan)
```