### PR TITLE
fix(cli): bound the index parsed by `neowall set <index>`

### DIFF
--- a/include/neowall/neowall.h
+++ b/include/neowall/neowall.h
@@ -131,6 +131,12 @@ void log_debug(const char *format, ...);
 void log_set_level(int level);
 float ease_in_out_cubic(float t);
 
+/* Parse a non-negative decimal index (wallpaper index, cycle_total, ...) from a
+ * string that came from the user or from disk. Rejects the empty string, any
+ * non-digit character, and values that overflow long, none of which atoi() can
+ * report. Returns true and writes *out on success. */
+bool neowall_parse_index(const char *s, long *out);
+
 /* State file functions */
 const char *get_state_file_path(void);
 const char *get_cycle_list_file_path(void);

--- a/src/main.c
+++ b/src/main.c
@@ -10,7 +10,7 @@
 #include <fcntl.h>
 #include <time.h>
 #include <sys/signalfd.h>
-#include <ctype.h>
+#include <limits.h>
 #include "neowall/neowall.h"
 #include "neowall/config/config_access.h"
 #include "neowall/constants.h"
@@ -322,8 +322,10 @@ static bool kill_daemon(void) {
 }
 
 /* Send signal to running daemon */
-/* Check if cycling is possible by reading state file */
-static bool can_cycle_wallpaper(void) {
+/* Largest cycle_total across all outputs in the state file, or 0 if the state
+ * file is absent or carries no usable cycle_total. This is the number of
+ * wallpapers `set <index>` can address. */
+static int state_max_cycle_total(void) {
     /* Use file-level locking (flock/fcntl) for cross-process synchronization.
      * We can't use the state_file_lock mutex here because this runs in a
      * separate process from the daemon; only file locks coordinate across
@@ -332,7 +334,7 @@ static bool can_cycle_wallpaper(void) {
     FILE *fp = fopen(state_path, "r");
 
     if (!fp) {
-        return false;  /* No state file = unknown, let daemon handle it */
+        return 0;  /* No state file = unknown, let daemon handle it */
     }
 
     /* Acquire read lock on the file */
@@ -359,9 +361,17 @@ static bool can_cycle_wallpaper(void) {
     while (fgets(line, sizeof(line), fp)) {
         line[strcspn(line, "\n")] = 0;
         if (strncmp(line, "cycle_total=", 12) == 0) {
-            int cycle_total = atoi(line + 12);
-            if (cycle_total > max_cycle_total) {
-                max_cycle_total = cycle_total;
+            /* The state file is on disk and can be truncated or hand-edited, so
+             * its contents are untrusted input: parse defensively rather than
+             * feeding an arbitrary digit string to atoi(). */
+            const char *value = line + 12;
+            long cycle_total = 0;
+            if (!neowall_parse_index(value, &cycle_total) || cycle_total > INT_MAX) {
+                log_debug("Ignoring malformed cycle_total in state file: '%s'", value);
+                continue;
+            }
+            if ((int)cycle_total > max_cycle_total) {
+                max_cycle_total = (int)cycle_total;
             }
             /* Don't break - continue checking all outputs */
         }
@@ -372,7 +382,12 @@ static bool can_cycle_wallpaper(void) {
     fcntl(fd, F_SETLK, &lock);
 
     fclose(fp);
-    return max_cycle_total > 1;  /* Can cycle if ANY output has more than 1 wallpaper */
+    return max_cycle_total;
+}
+
+/* Check if cycling is possible: ANY output has more than one wallpaper. */
+static bool can_cycle_wallpaper(void) {
+    return state_max_cycle_total() > 1;
 }
 
 static bool send_daemon_signal(int signal, const char *action, bool check_cycle) {
@@ -826,16 +841,16 @@ int main(int argc, char *argv[]) {
                 fprintf(stderr, "\nUse '%s current' to see available wallpapers and their indices.\n", argv[0]);
                 return EXIT_FAILURE;
             }
-            /* Validate index is a number */
+            /* Validate index is a number. atoi() cannot report failure and is
+             * undefined on overflow, so parse with a checked helper: "9999999999"
+             * is all digits but does not fit in an int. */
             const char *index_str = argv[2];
-            for (const char *p = index_str; *p; p++) {
-                if (!isdigit((unsigned char)*p)) {
-                    fprintf(stderr, "Error: Index must be a non-negative integer, got '%s'\n", index_str);
-                    return EXIT_FAILURE;
-                }
+            long parsed = 0;
+            if (!neowall_parse_index(index_str, &parsed) || parsed > INT_MAX) {
+                fprintf(stderr, "Error: Index must be a non-negative integer, got '%s'\n", index_str);
+                return EXIT_FAILURE;
             }
-            int index = atoi(index_str);
-            
+
             /* Send set-index command to daemon */
             const char *pid_path = get_pid_file_path();
             FILE *fp = fopen(pid_path, "r");
@@ -861,10 +876,20 @@ int main(int argc, char *argv[]) {
             }
 
             /* Check if cycling is possible */
-            if (!can_cycle_wallpaper()) {
+            int cycle_total = state_max_cycle_total();
+            if (cycle_total <= 1) {
                 printf("Cannot set wallpaper index: Only one wallpaper/shader configured.\n");
                 return EXIT_FAILURE;
             }
+
+            /* Bound the index against what the daemon actually has. Without this
+             * the CLI reports success for an index no output can honour, and the
+             * daemon silently drops the request. */
+            if (parsed >= cycle_total) {
+                fprintf(stderr, "Error: Index %ld is out of range (0-%d)\n", parsed, cycle_total - 1);
+                return EXIT_FAILURE;
+            }
+            int index = (int)parsed;
 
             /* Write the index to a file for the daemon to read */
             if (!write_set_index_file(index)) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -131,6 +131,39 @@ void log_set_colors(bool enabled) {
  * locale-ignorant duplicate here that shadowed the libc symbol. Removed in
  * audit fix #28. */
 
+/* Parse a non-negative decimal index out of `s`.
+ *
+ * atoi(3) has no way to report failure, and C11 7.22.1p1 makes it undefined
+ * behaviour when the value cannot be represented as an int - so a digit string
+ * that overflows int cannot be handled safely by the caller. Values that come
+ * from the command line or from the on-disk state file go through this instead.
+ *
+ * Accepts only a non-empty run of decimal digits: no sign, no leading or
+ * trailing whitespace, no trailing garbage. Overflow (ERANGE) is rejected
+ * rather than clamped. On success stores the value in *out and returns true;
+ * *out is untouched on failure. */
+bool neowall_parse_index(const char *s, long *out) {
+    if (!s || !out || *s == '\0') {
+        return false;
+    }
+
+    for (const char *p = s; *p; p++) {
+        if (*p < '0' || *p > '9') {
+            return false;
+        }
+    }
+
+    errno = 0;
+    char *end = NULL;
+    long value = strtol(s, &end, 10);
+    if (end == s || *end != '\0' || errno == ERANGE || value < 0) {
+        return false;
+    }
+
+    *out = value;
+    return true;
+}
+
 /* Path expansion (tilde expansion) */
 bool expand_path(const char *path, char *expanded, size_t size) {
     if (!path || !expanded || size == 0) {

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include <errno.h>
+#include <limits.h>
 #include <time.h>
 
 /* Prototypes from src/utils.c (kept in sync with include/neowall.h). */
@@ -28,6 +29,7 @@ float ease_in_out_cubic(float t);
 void format_bytes(uint64_t bytes, char *buf, size_t size);
 bool expand_path(const char *path, char *expanded, size_t size);
 const char *neowall_secure_runtime_dir(void);
+bool neowall_parse_index(const char *s, long *out);
 
 static int failures = 0;
 static int checks = 0;
@@ -113,6 +115,56 @@ static void test_expand_path(void) {
     CHECK(!expand_path("/x", out, 0));
 }
 
+/* neowall_parse_index(): the checked replacement for atoi() on user- and
+ * disk-supplied index strings. The case that atoi() gets wrong is the one at
+ * the bottom: an all-digit string too large for an int. */
+static void test_parse_index(void) {
+    long v;
+
+    /* Plain non-negative decimals. */
+    v = -1;
+    CHECK(neowall_parse_index("0", &v) && v == 0);
+    v = -1;
+    CHECK(neowall_parse_index("7", &v) && v == 7);
+    v = -1;
+    CHECK(neowall_parse_index("0042", &v) && v == 42);
+
+    /* Not a number, or not entirely a number. */
+    v = -1;
+    CHECK(!neowall_parse_index("", &v));
+    CHECK(!neowall_parse_index("abc", &v));
+    CHECK(!neowall_parse_index("3x", &v));
+    CHECK(!neowall_parse_index("3 ", &v));
+    CHECK(!neowall_parse_index(" 3", &v));
+    CHECK(!neowall_parse_index("+3", &v));
+    CHECK(!neowall_parse_index("-1", &v));
+    CHECK(!neowall_parse_index("0x10", &v));
+    CHECK(!neowall_parse_index(NULL, &v));
+    CHECK(v == -1);   /* nothing written on failure */
+
+    /* Overflow: all digits, but far past what an int (or a long) can hold.
+     * atoi("99999999999999999999") is undefined behaviour; in practice glibc
+     * saturates and truncates, handing the caller a bogus index. */
+    CHECK(!neowall_parse_index("99999999999999999999", &v));
+
+    /* LONG_MAX itself parses; LONG_MAX + 1 does not. */
+    char buf[32];
+    snprintf(buf, sizeof(buf), "%ld", LONG_MAX);
+    v = -1;
+    CHECK(neowall_parse_index(buf, &v) && v == LONG_MAX);
+    snprintf(buf, sizeof(buf), "%lu", (unsigned long)LONG_MAX + 1UL);
+    CHECK(!neowall_parse_index(buf, &v));
+
+#if LONG_MAX > INT_MAX
+    /* INT_MAX + 1: fits in a long, so the parse succeeds and the caller is the
+     * one that must reject it - which is exactly why the value is reported
+     * rather than silently squeezed into an int, as atoi() would. */
+    snprintf(buf, sizeof(buf), "%ld", (long)INT_MAX + 1);
+    v = -1;
+    CHECK(neowall_parse_index(buf, &v) && v == (long)INT_MAX + 1);
+#endif
+}
+
 /* neowall_secure_runtime_dir(): must create a private 0700 directory we own
  * under XDG_RUNTIME_DIR, and must REFUSE a name already taken by a symlink
  * (the /tmp squat attack the hardening closes). */
@@ -163,6 +215,7 @@ int main(void) {
     test_ease();
     test_format_bytes();
     test_expand_path();
+    test_parse_index();
     test_secure_runtime_dir();
 
     if (failures == 0) {


### PR DESCRIPTION
`set <index>` validates its argument with an `isdigit()` loop and then converts it with `atoi()`. The loop rejects negatives and trailing garbage, but nothing bounds the value, so any all-digit string is accepted:

```
neowall set 4294967296   -> atoi() yields 0; wallpaper 0 is set, and the CLI prints
                            "Setting wallpaper to index 4294967296..." and exits 0
neowall set 2147483648   -> atoi() yields INT_MIN; the daemon's set_index >= 0 guard
                            drops it, and the CLI still reports success
neowall set ""           -> the digit loop has nothing to reject, so it is index 0
```

`atoi()` cannot report failure, and C11 7.22.1p1 makes it undefined behaviour on an unrepresentable value.

This parses with `strtol`, rejects empty input and `ERANGE`, and bounds the index against the real cycle count. The state file's `cycle_total` gets the same treatment, being untrusted input.

`eventloop.c` already bound-checks the index before use, so today the outcome is the wrong wallpaper being set, or a no-op reported as success.

`meson test` 9/9. The new checks pin the helper's behaviour; against the old parse they do not fail, because the helper does not exist there.

This conflicts with `macos-port` in `src/main.c`, where signal dispatch moves to `NW_SIG_*` macros and `nw_signalfd_create()` in the same region. I can rebase onto that branch instead if it lands first.
