### PR TITLE
fix(wayland): track every output a toplevel is on, not just the last

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -286,6 +286,7 @@ if has_wayland
   )
   occlusion_sources += files(
     'src/compositor/backends/wayland/occlusion.c',
+    'src/compositor/backends/wayland/occlusion_set.c',
     'src/compositor/backends/wayland/frame_watchdog.c',
     'src/compositor/backends/wayland/hyprland_coverage.c',
   )
@@ -504,6 +505,18 @@ test_x11_geometry_exe = executable('test_x11_geometry',
 )
 
 test('x11_geometry', test_x11_geometry_exe)
+
+# Wayland toplevel output set — a toplevel can occupy several outputs at once.
+# Pure pointer-set logic, no Wayland headers or display needed.
+test_occlusion_set_exe = executable('test_occlusion_set',
+  files('tests/test_occlusion_set.c',
+        'src/compositor/backends/wayland/occlusion_set.c'),
+  include_directories: [inc_dirs, inc_dirs_build,
+                        include_directories('src/compositor/backends/wayland')],
+  build_by_default: false,
+)
+
+test('occlusion_set', test_occlusion_set_exe)
 
 # Reactive audio FFT — pure math, no audio thread / parec needed.
 test_fft_exe = executable('test_reactive_fft',

--- a/src/compositor/backends/wayland/occlusion.c
+++ b/src/compositor/backends/wayland/occlusion.c
@@ -24,27 +24,32 @@
 #include "wayland_occlusion.h"
 #include "frame_watchdog.h"
 #include "hyprland_coverage.h"
+#include "occlusion_set.h"
 
 /* ---------- per-toplevel state tracking ---------- */
 
 typedef struct tracked_toplevel {
     struct zwlr_foreign_toplevel_handle_v1 *handle;
     uint32_t state;
-    struct wl_output *output;
-    bool has_output;
+    output_set outputs;   /* every wl_output this toplevel is currently on */
     struct tracked_toplevel *next;
 } tracked_toplevel_t;
 
 static struct zwlr_foreign_toplevel_manager_v1 *toplevel_manager = NULL;
 static tracked_toplevel_t *toplevels = NULL;
 
+static void free_toplevel(tracked_toplevel_t *tl) {
+    output_set_free(&tl->outputs);
+    zwlr_foreign_toplevel_handle_v1_destroy(tl->handle);
+    free(tl);
+}
+
 static void remove_toplevel(tracked_toplevel_t *tl) {
     tracked_toplevel_t **pp = &toplevels;
     while (*pp) {
         if (*pp == tl) {
             *pp = tl->next;
-            zwlr_foreign_toplevel_handle_v1_destroy(tl->handle);
-            free(tl);
+            free_toplevel(tl);
             return;
         }
         pp = &(*pp)->next;
@@ -60,16 +65,14 @@ static void tl_app_id(void *d, struct zwlr_foreign_toplevel_handle_v1 *h, const 
 static void tl_output_enter(void *d, struct zwlr_foreign_toplevel_handle_v1 *h,
                             struct wl_output *output) {
     tracked_toplevel_t *tl = d; (void)h;
-    tl->output = output;
-    tl->has_output = true;
+    /* A toplevel may be visible on several outputs at once, so accumulate
+     * rather than overwrite. */
+    output_set_add(&tl->outputs, output);
 }
 static void tl_output_leave(void *d, struct zwlr_foreign_toplevel_handle_v1 *h,
                             struct wl_output *output) {
     tracked_toplevel_t *tl = d; (void)h;
-    if (tl->output == output) {
-        tl->output = NULL;
-        tl->has_output = false;
-    }
+    output_set_remove(&tl->outputs, output);
 }
 static void tl_state(void *d, struct zwlr_foreign_toplevel_handle_v1 *h,
                      struct wl_array *state) {
@@ -111,6 +114,7 @@ static void mgr_toplevel(void *d, struct zwlr_foreign_toplevel_manager_v1 *m,
         return;
     }
     tl->handle = handle;
+    output_set_init(&tl->outputs);
     tl->next = toplevels;
     toplevels = tl;
     zwlr_foreign_toplevel_handle_v1_add_listener(handle, &tl_listener, tl);
@@ -166,7 +170,7 @@ static bool any_covering_toplevel_on(struct wl_output *output) {
     const uint32_t mn = 1u << ZWLR_FOREIGN_TOPLEVEL_HANDLE_V1_STATE_MINIMIZED;
     const uint32_t ac = 1u << ZWLR_FOREIGN_TOPLEVEL_HANDLE_V1_STATE_ACTIVATED;
     for (tracked_toplevel_t *tl = toplevels; tl; tl = tl->next) {
-        if (!tl->has_output || tl->output != output) {
+        if (!output_set_contains(&tl->outputs, output)) {
             continue;
         }
         if (tl->state & mn) {
@@ -262,8 +266,7 @@ void wayland_occlusion_cleanup(void) {
     frame_watchdog_cleanup();
     while (toplevels) {
         tracked_toplevel_t *next = toplevels->next;
-        zwlr_foreign_toplevel_handle_v1_destroy(toplevels->handle);
-        free(toplevels);
+        free_toplevel(toplevels);
         toplevels = next;
     }
     if (toplevel_manager) {

--- a/src/compositor/backends/wayland/occlusion_set.c
+++ b/src/compositor/backends/wayland/occlusion_set.c
@@ -1,0 +1,36 @@
+#include "occlusion_set.h"
+
+bool output_set_add(output_set *set, void *output) {
+    if (!set || !output) {
+        return false;
+    }
+    if (output_set_contains(set, output)) {
+        return true;
+    }
+    return output_set_push(set, output);
+}
+
+void output_set_remove(output_set *set, void *output) {
+    if (!set || !output) {
+        return;
+    }
+    for (size_t i = 0; i < set->len; i++) {
+        if (set->data[i] == output) {
+            set->data[i] = set->data[set->len - 1];
+            set->len--;
+            return;
+        }
+    }
+}
+
+bool output_set_contains(const output_set *set, const void *output) {
+    if (!set || !output) {
+        return false;
+    }
+    for (size_t i = 0; i < set->len; i++) {
+        if (set->data[i] == output) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/compositor/backends/wayland/occlusion_set.h
+++ b/src/compositor/backends/wayland/occlusion_set.h
@@ -1,0 +1,29 @@
+#ifndef NEOWALL_WAYLAND_OCCLUSION_SET_H
+#define NEOWALL_WAYLAND_OCCLUSION_SET_H
+
+/* The set of outputs one toplevel currently occupies.
+ *
+ * wlr-foreign-toplevel-management sends one output_enter per output the
+ * toplevel is visible on, and the protocol states plainly that "a toplevel may
+ * be visible on multiple outputs"; output_leave is guaranteed to be preceded by
+ * an output_enter for the same output. Occlusion must therefore be decided by
+ * set membership, never against a single "most recent" handle.
+ *
+ * Elements are opaque wl_output* handles, so this unit stays free of Wayland
+ * headers and can be exercised without a display. */
+
+#include <stdbool.h>
+
+#include "neowall/vec.h"
+
+NW_VEC_DEFINE_STATIC(output_set, void *)
+
+/* Idempotent. Returns false only on OOM, leaving the set unchanged. */
+bool output_set_add(output_set *set, void *output);
+
+/* Removes `output` if present; no-op otherwise. Order is not preserved. */
+void output_set_remove(output_set *set, void *output);
+
+bool output_set_contains(const output_set *set, const void *output);
+
+#endif /* NEOWALL_WAYLAND_OCCLUSION_SET_H */

--- a/tests/test_occlusion_set.c
+++ b/tests/test_occlusion_set.c
@@ -1,0 +1,141 @@
+/* Unit tests for the Wayland toplevel output set (occlusion_set.c).
+ *
+ * wlr-foreign-toplevel-management sends one output_enter per output a toplevel
+ * is visible on, and the protocol allows a toplevel to be visible on several
+ * outputs at once, so occlusion is a set-membership question. Tracking only the
+ * most recently entered output loses every other one, and a window is then
+ * missed as an occluder on the outputs it also covers.
+ *
+ * The set stores opaque wl_output* handles, so these tests use fake pointers
+ * and need no display.
+ */
+#include <stdbool.h>
+#include <stdio.h>
+
+#include "occlusion_set.h"
+
+static int failures = 0;
+static int checks = 0;
+
+#define CHECK(cond)                                                            \
+    do {                                                                       \
+        checks++;                                                              \
+        if (!(cond)) {                                                         \
+            failures++;                                                        \
+            fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);    \
+        }                                                                      \
+    } while (0)
+
+/* Stand-ins for wl_output handles; only their addresses matter. */
+static char out_a, out_b, out_c;
+#define A ((void *)&out_a)
+#define B ((void *)&out_b)
+#define C ((void *)&out_c)
+
+static void test_empty_set_contains_nothing(void) {
+    output_set s;
+    output_set_init(&s);
+    CHECK(!output_set_contains(&s, A));
+    CHECK(!output_set_contains(&s, NULL));
+    output_set_free(&s);
+}
+
+static void test_membership_is_per_output(void) {
+    output_set s;
+    output_set_init(&s);
+    CHECK(output_set_add(&s, A));
+    CHECK(output_set_contains(&s, A));
+    CHECK(!output_set_contains(&s, B));
+
+    /* Entering a second output must not evict the first (the single-pointer
+     * bug: last enter wins, so a window straddling A and B is only ever
+     * attributed to B). */
+    CHECK(output_set_add(&s, B));
+    CHECK(output_set_contains(&s, A));
+    CHECK(output_set_contains(&s, B));
+    CHECK(!output_set_contains(&s, C));
+    CHECK(s.len == 2);
+    output_set_free(&s);
+}
+
+static void test_add_is_idempotent(void) {
+    output_set s;
+    output_set_init(&s);
+    CHECK(output_set_add(&s, A));
+    CHECK(output_set_add(&s, A));
+    CHECK(output_set_add(&s, A));
+    CHECK(s.len == 1);
+    CHECK(!output_set_add(&s, NULL));
+    CHECK(s.len == 1);
+    output_set_free(&s);
+}
+
+static void test_leave_removes_only_that_output(void) {
+    output_set s;
+    output_set_init(&s);
+    output_set_add(&s, A);
+    output_set_add(&s, B);
+    output_set_add(&s, C);
+
+    /* Leaving one output must not drop the toplevel's other outputs (the
+     * single-pointer bug: leaving the tracked output cleared it outright, so a
+     * window still fullscreen elsewhere stopped counting as an occluder). */
+    output_set_remove(&s, B);
+    CHECK(s.len == 2);
+    CHECK(output_set_contains(&s, A));
+    CHECK(!output_set_contains(&s, B));
+    CHECK(output_set_contains(&s, C));
+
+    /* Removing an absent output is a no-op. */
+    output_set_remove(&s, B);
+    CHECK(s.len == 2);
+
+    output_set_remove(&s, A);
+    output_set_remove(&s, C);
+    CHECK(s.len == 0);
+    CHECK(!output_set_contains(&s, A));
+    output_set_free(&s);
+}
+
+static void test_reenter_after_leave(void) {
+    output_set s;
+    output_set_init(&s);
+    output_set_add(&s, A);
+    output_set_remove(&s, A);
+    CHECK(!output_set_contains(&s, A));
+    CHECK(output_set_add(&s, A));
+    CHECK(output_set_contains(&s, A));
+    CHECK(s.len == 1);
+    output_set_free(&s);
+}
+
+static void test_grows_past_initial_capacity(void) {
+    static char outs[64];
+    output_set s;
+    output_set_init(&s);
+    for (int i = 0; i < 64; i++) {
+        CHECK(output_set_add(&s, &outs[i]));
+    }
+    CHECK(s.len == 64);
+    for (int i = 0; i < 64; i++) {
+        CHECK(output_set_contains(&s, &outs[i]));
+    }
+    output_set_free(&s);
+    CHECK(s.len == 0);
+}
+
+int main(void) {
+    test_empty_set_contains_nothing();
+    test_membership_is_per_output();
+    test_add_is_idempotent();
+    test_leave_removes_only_that_output();
+    test_reenter_after_leave();
+    test_grows_past_initial_capacity();
+
+    if (failures == 0) {
+        printf("ok - %d checks passed\n", checks);
+        return 0;
+    }
+    fprintf(stderr, "not ok - %d/%d checks failed\n", failures, checks);
+    return 1;
+}


### PR DESCRIPTION
Replaces the single tracked `wl_output *` with a small set: `output_enter` adds, `output_leave` removes, and `any_covering_toplevel_on()` asks for membership. Adds are idempotent. The set is freed with the toplevel.

`tracked_toplevel` held one pointer, overwritten on each `output_enter`. wlr-foreign-toplevel-management sends one `output_enter` per output a window is visible on, and the protocol states that "a toplevel may be visible on multiple outputs", so a later enter evicted the earlier one.

With `pause_on_fullscreen` on a multi-monitor setup, a window spanning two outputs is attributed only to the last one entered, so the other output never sees it and keeps rendering its wallpaper underneath. `output_leave` also cleared the pointer outright, so a window leaving the tracked output stopped being tracked anywhere, while still fullscreen on the other one.

The cost is a missed pause, never a wrongly blanked screen: the tracked pointer is always an output the window is genuinely on, so the old code could only under-report occlusion.

This is the guarantee described when #35 was closed: "it's per-monitor so only the covered screen pauses".

`meson test` 10/10, including a new `test_occlusion_set`. The set stores opaque handles and pulls in no Wayland headers, so the test needs no display.

I have no Wayland session, so this is backed by the protocol text and those unit tests, not by a run on a live compositor.
