### PR TITLE
fix(wayland): set initialized only once the registry is fully up, and guard re-entry

### DIFF
--- a/src/compositor/backends/wayland/wayland_core.c
+++ b/src/compositor/backends/wayland/wayland_core.c
@@ -491,6 +491,26 @@ bool wayland_init_registry(struct neowall_state *state) {
 
     wayland_t *wl = &g_wayland;
 
+    /* Guard re-entry: the memset below would zero a live wayland_t, dropping the
+     * open wl_display and every bound global without destroying them, while
+     * state->outputs kept pointing at them. wayland_cleanup() clears this flag,
+     * so a genuine re-init after teardown still proceeds.
+     *
+     * Returning true here is only sound because wl->initialized is now set at
+     * the single success exit below: every failure path returns false with the
+     * flag still clear, so "initialized" means "fully built". */
+    if (wl->initialized) {
+        return true;
+    }
+
+    /* An earlier attempt can fail after the display is connected (the failure
+     * paths below return without disconnecting), leaving wl->display open with
+     * wl->initialized still false. Release it before the memset drops the last
+     * reference to that connection. */
+    if (wl->display) {
+        wayland_cleanup();
+    }
+
     /* Initialize the wayland structure */
     memset(wl, 0, sizeof(wayland_t));
     wl->state = state;
@@ -531,9 +551,6 @@ bool wayland_init_registry(struct neowall_state *state) {
         log_error("Compositor not available");
         return false;
     }
-
-    /* Mark as initialized */
-    wl->initialized = true;
 
     /* Shared memory buffers not available */
     if (!wl->shm) {
@@ -576,6 +593,13 @@ bool wayland_init_registry(struct neowall_state *state) {
         free(wl->cursor_theme_name);
         wl->cursor_theme_name = NULL;
     }
+
+    /* Mark as initialized at the single success exit, not before the wl_shm
+     * check: setting it earlier left the flag true on a registry that had no
+     * shm and had returned false, so wayland_available() reported a usable
+     * Wayland and the re-entry guard above would have reported success on a
+     * half-built registry. */
+    wl->initialized = true;
 
     return true;
 }


### PR DESCRIPTION
Addresses (1) and (2) of #56.

`wayland_init_registry()` sets `wl->initialized` at `wayland_core.c:536`, before it has finished: it can still return false at `:539-542` if `wl_shm` is missing, and cursor state is set up after that. So the flag can say "initialized" on a registry that was never fully built, and `wayland_available()` (`:38`) reports it as usable.

This moves the flag to the single success exit, so every failure path returns false with it still clear. That in turn makes it sound to use as the re-entry guard its name and placement already imply, which stops a second call memsetting a live `wayland_t` and leaking the open display and bound globals.

Latent, not currently triggered: the only live path in is `compositor_backend_init()` (`compositor_registry.c:462`), reached once from `main()`. The double-entry path is inside `wayland_init_full()`, which has no callers. Point (3) of #56, whether to delete that function, is left to you.

## What I tested, and what I could not

`meson test` passes 9/9 on this branch.

There is no Wayland session on my machine, so I have not run this against a live compositor, and there is no unit test for the guard: the flag is only reachable through a successful `wl_display_connect()`, and `g_wayland` is file-static with no seam. I would rather say that than write a test that asserts nothing.
