### PR TITLE
x11: let the window manager stack the wallpaper as the desktop

### DIFF
--- a/include/neowall/compositor/compositor.h
+++ b/include/neowall/compositor/compositor.h
@@ -340,7 +340,23 @@ typedef struct compositor_backend_ops {
      * @return true on success, false on failure
      */
     bool (*prepare_events)(void *backend_data);
-    
+
+    /**
+     * Optional: does the backend already hold events that poll() will not see?
+     *
+     * Xlib keeps a userspace event queue. Any Xlib call that talks to the server
+     * (XSync, XFlush, XPending) can drain the connection socket into that queue,
+     * so events can be waiting for us while poll() on get_fd() reports nothing
+     * readable and blocks for the full timeout. A backend with an internal queue
+     * reports it here so the event loop does not sleep on work it already has.
+     *
+     * Leave NULL if the backend has no such queue; the loop then just polls.
+     *
+     * @param backend_data Data returned from init()
+     * @return true if events are already queued and dispatch should run now
+     */
+    bool (*has_pending_events)(void *backend_data);
+
     /**
      * Read events from compositor
      * Reads events from the compositor (may block if prepared).

--- a/meson.build
+++ b/meson.build
@@ -312,6 +312,7 @@ if has_x11
   x11_sources = files(
     'src/compositor/backends/x11/x11_core.c',
     'src/compositor/backends/x11/x11_geometry.c',
+    'src/compositor/backends/x11/x11_wm_detect.c',
   )
   occlusion_sources += files('src/compositor/backends/x11/x11_occlusion.c')
 endif
@@ -507,6 +508,18 @@ test_x11_geometry_exe = executable('test_x11_geometry',
 )
 
 test('x11_geometry', test_x11_geometry_exe)
+
+# X11 window-manager detection — the _NET_SUPPORTING_WM_CHECK decision matrix,
+# the NEOWALL_X11_OVERRIDE_REDIRECT contract, and the heal-on-late-WM edge.
+# Pure decision logic, no Xlib/display needed (see x11_wm_detect.c).
+test_x11_wm_detect_exe = executable('test_x11_wm_detect',
+  files('tests/test_x11_wm_detect.c',
+        'src/compositor/backends/x11/x11_wm_detect.c'),
+  include_directories: [inc_dirs, inc_dirs_build],
+  build_by_default: false,
+)
+
+test('x11_wm_detect', test_x11_wm_detect_exe)
 
 # Wayland toplevel output set — a toplevel can occupy several outputs at once.
 # Pure pointer-set logic, no Wayland headers or display needed.

--- a/src/compositor/backends/x11/README.md
+++ b/src/compositor/backends/x11/README.md
@@ -138,7 +138,7 @@ bspc rule -a NeoWall state=floating layer=below
 X11 Backend
 ├── Display Connection (Xlib)
 ├── Window Management
-│   ├── XCreateSimpleWindow()
+│   ├── XCreateWindow() (managed or override-redirect, per WM detection)
 │   ├── EWMH property setup
 │   └── XRandR multi-monitor
 ├── EGL Integration
@@ -148,24 +148,89 @@ X11 Backend
 └── Event Handling
     ├── ConfigureNotify (resize)
     ├── Expose (redraw)
+    ├── PropertyNotify on root (_NET_SUPPORTING_WM_CHECK: a WM started/exited)
     └── RRScreenChangeNotify (monitor changes)
 ```
 
 ### Window Properties Set
 
-The backend automatically sets these X11 properties:
+Every wallpaper window carries these properties, set before it is mapped
+(`x11_set_wallpaper_properties`, `x11_core.c`):
 
 ```c
 _NET_WM_WINDOW_TYPE = _NET_WM_WINDOW_TYPE_DESKTOP
 _NET_WM_STATE = [
     _NET_WM_STATE_BELOW,
-    _NET_WM_STATE_STICKY,
+    _NET_WM_STATE_STICKY,        /* viewport-fixed; NOT "all desktops" */
     _NET_WM_STATE_SKIP_TASKBAR,
     _NET_WM_STATE_SKIP_PAGER
 ]
-WM_CLASS = "neowall\0NeoWall"
-WM_NAME = "NeoWall Wallpaper"
+_NET_WM_DESKTOP = 0xFFFFFFFF     /* all desktops (EWMH 5.5 / 9.2) */
+WM_CLASS        = "neowall", "NeoWall"   /* instance, class */
+WM_NAME         = "NeoWall Wallpaper"
+_NET_WM_NAME    = "NeoWall Wallpaper"    /* UTF8_STRING */
+WM_NORMAL_HINTS = { PPosition, PSize }   /* our geometry, not WM policy */
+WM_HINTS        = { input: False }       /* never takes keyboard focus */
 ```
+
+`WM_CLASS` is what a WM rule keys on, so it is also the handle you need to
+override our stacking if your WM gets it wrong — see
+[Wallpaper Appears Above Windows](#wallpaper-appears-above-windows).
+
+`WM_NORMAL_HINTS` matters on multi-monitor: ICCCM 4.1.2.3 makes a managed
+window's requested position merely advisory without `PPosition`, which would let
+the WM place a per-monitor wallpaper window on the wrong monitor.
+
+### Window Stacking: Managed vs Override-Redirect
+
+An override-redirect window is by definition **not managed**, so no WM ever reads
+its `_NET_WM_WINDOW_TYPE` and the `DESKTOP` hint above has no effect. The backend
+therefore picks per-display:
+
+| Situation | Window is | Stacked by |
+|---|---|---|
+| EWMH WM that advertises `_NET_WM_WINDOW_TYPE_DESKTOP` | managed | the WM, as the desktop |
+| EWMH WM that does not advertise it (dwm, i3) | override-redirect | `XLowerWindow` + raising the root's other children |
+| No WM (bare X, or a non-EWMH WM) | override-redirect | `XLowerWindow` + raising the root's other children |
+
+The WM is detected with the two-step `_NET_SUPPORTING_WM_CHECK` handshake (EWMH
+1.5): the root property names a window, and that window must carry the same
+property naming *itself*. A WM that exited without cleaning up leaves the root
+property behind, so only the self-reference proves one is actually alive.
+
+Liveness alone does not earn a managed window: the WM must also list
+`_NET_WM_WINDOW_TYPE_DESKTOP` in `_NET_SUPPORTED` (which EWMH says "MUST" name
+every supported hint). dwm and i3 pass the handshake but omit it, and neither
+honours the hint — dwm tiles every managed window, and i3 floats a window
+carrying `_NET_WM_DESKTOP=0xFFFFFFFF` above the tiling layer — so a managed
+wallpaper there would become an ordinary client window. Such WMs keep the
+override-redirect path; a WM that honours `DESKTOP` without advertising it can
+be forced managed with `NEOWALL_X11_OVERRIDE_REDIRECT=0` (below).
+
+**A window manager that starts after us is handled.** A wallpaper daemon is
+autostarted at login and routinely wins the race against the WM. The backend
+selects `PropertyChangeMask` on the root, and when `_NET_SUPPORTING_WM_CHECK`
+or `_NET_SUPPORTED` changes it re-runs the probe (a starting WM may write those
+two properties in either order); if a WM has appeared, the wallpaper windows are
+destroyed and recreated on the managed path. They must be *recreated* —
+`override_redirect` is fixed at `XCreateWindow` time, so re-setting properties on
+the existing window would not hand it to the WM. The shared `EGLContext` outlives
+the swap, so textures and compiled shaders are not rebuilt.
+
+**A window manager that dies is handled too.** When the WM goes away the window is
+rebuilt on the override-redirect path, restoring exactly the setup the daemon
+would have had if it had started with no WM. This is not cosmetic: when the WM
+dies the wallpaper window loses its contents, and for a static image
+`needs_redraw` has already been cleared after the first frame, so nothing ever
+repaints it — the wallpaper goes black and stays black. Rebuilding repaints it and
+re-arms the `XLowerWindow` path.
+
+A WM *restart* (`--replace`) flaps the property down and straight back up, so the
+WM-went-away edge is **debounced** (`X11_WM_GONE_DEBOUNCE_MS`, 1.5 s): the daemon
+waits, re-probes, and only rebuilds if no replacement has appeared. A restart
+therefore costs zero window rebuilds. Both edges are idempotent — the action is
+derived from the window state actually in use, so a repeated `PropertyNotify`
+does nothing.
 
 ### EGL Context Creation
 
@@ -212,12 +277,39 @@ notify with an unchanged layout is a no-op.
 
 ### Wallpaper Appears Above Windows
 
-**Cause:** Window manager not respecting EWMH hints
+**Cause:** Window manager not respecting EWMH hints, or the backend picked the
+wrong window type for your WM.
 
 **Solution:**
-1. Check if WM supports EWMH: `xprop -root | grep _NET_SUPPORTED`
-2. Add manual rules (see WM-specific sections above)
-3. Try a compositor like `picom` for better stacking
+1. Check if WM advertises desktop windows: `xprop -root _NET_SUPPORTED | grep -o _NET_WM_WINDOW_TYPE_DESKTOP`
+2. Check what the backend actually chose — run with `-f -v` and look for one of:
+   ```
+   X11: EWMH window manager with _NET_WM_WINDOW_TYPE_DESKTOP support detected - using managed wallpaper windows
+   X11: EWMH window manager detected, but its _NET_SUPPORTED does not advertise _NET_WM_WINDOW_TYPE_DESKTOP - using override-redirect wallpaper windows
+   X11: no EWMH window manager - using override-redirect wallpaper windows
+   ```
+3. Override the choice with `NEOWALL_X11_OVERRIDE_REDIRECT` (see below)
+4. Add manual rules keyed on `WM_CLASS` (see WM-specific sections above), e.g.
+   i3: `for_window [class="NeoWall"] ...`
+5. Try a compositor like `picom` for better stacking
+
+#### `NEOWALL_X11_OVERRIDE_REDIRECT`
+
+Escape hatch for a WM that mishandles the auto-detected choice. Accepts exactly
+two values; anything else logs a warning and is ignored.
+
+| Value | Effect |
+|---|---|
+| `1` | Force **override-redirect**. The WM never manages or stacks the wallpaper; `XLowerWindow` keeps it at the bottom. Use if your WM stacks the desktop window *above* other windows. |
+| `0` | Force a **managed** window. Use if auto-detection fails to see your WM but it does honour `_NET_WM_WINDOW_TYPE_DESKTOP`. |
+| unset | Auto-detect (the default), and switch to managed if a WM appears later. |
+
+```bash
+NEOWALL_X11_OVERRIDE_REDIRECT=1 neowall -f -v
+```
+
+Setting either value **pins** the choice: the backend will not revise it if a
+window manager starts or exits later.
 
 ### Black Screen / No Rendering
 

--- a/src/compositor/backends/x11/x11_core.c
+++ b/src/compositor/backends/x11/x11_core.c
@@ -20,6 +20,7 @@
 #include "neowall/config/config.h"
 #include "x11_occlusion.h"
 #include "x11_geometry.h"
+#include "x11_wm_detect.h"
 #include "neowall/output/output.h"
 
 /*
@@ -71,11 +72,58 @@ typedef struct {
     Atom atom_net_wm_state_sticky;
     Atom atom_net_wm_state_skip_taskbar;
     Atom atom_net_wm_state_skip_pager;
+    Atom atom_net_wm_desktop;
+    Atom atom_net_wm_name;
+    Atom atom_utf8_string;
+    Atom atom_net_supporting_wm_check;
+    Atom atom_net_supported;
+
+    /* Root-pixmap advertisement, for pseudo-transparency clients. */
+    Atom atom_xrootpmap_id;
+    Atom atom_esetroot_pmap_id;
+
+    /* The pixmap XID currently advertised by _XROOTPMAP_ID / ESETROOT_PMAP_ID
+     * because we put it there. 0 when we have advertised nothing (or have since
+     * withdrawn it). Tracked on the backend, not the surface, because the
+     * properties are a screen-wide singleton that outlives any one surface: a
+     * window rebuild destroys the surface that published, and the replacement
+     * must not be able to leave the root naming a pixmap that no longer exists. */
+    Pixmap published_root_pixmap;
 
     /* XRandR support */
     bool has_xrandr;
     int xrandr_event_base;
     int xrandr_error_base;
+
+    /* How every per-monitor window is currently created. Resolved at init, and
+     * revised if a window manager appears later (see x11_recheck_wm). */
+    bool override_redirect;
+
+    /* NEOWALL_X11_OVERRIDE_REDIRECT pinned the choice: never auto-revise it. */
+    bool or_env_forced;
+
+    /* Result of the last WM probe: a live EWMH WM that advertises
+     * _NET_WM_WINDOW_TYPE_DESKTOP in _NET_SUPPORTED, i.e. one we should hand a
+     * managed window to. Cached so a PropertyNotify that does not change the
+     * answer costs nothing. */
+    bool wm_present;
+
+    /* The last probe saw a live EWMH WM, whether or not it advertises desktop
+     * support (dwm and i3 announce EWMH but tile/float DESKTOP windows). Only
+     * consulted for logging, so a user can tell "no WM" from "your WM does not
+     * advertise _NET_WM_WINDOW_TYPE_DESKTOP". */
+    bool wm_alive;
+
+    /* When the WM went away, the time (ms) at which we stop giving it the benefit
+     * of the doubt and rebuild on the override-redirect path. 0 = nothing pending.
+     * Debounces a WM restart, which flaps the property down and back up. */
+    uint64_t wm_gone_deadline_ms;
+
+    /* The window named by _NET_SUPPORTING_WM_CHECK at the last successful probe.
+     * We select StructureNotifyMask on it so that its DestroyNotify tells us the
+     * WM has gone: a WM killed outright (kill -9, crash) does not clean up the
+     * root property, so waiting for a PropertyNotify would wait forever. */
+    Window wm_check_window;
 
     bool occlusion_active;
 
@@ -92,7 +140,12 @@ typedef struct {
                             * background pixmap for pseudo-transparency. Secondary
                             * monitors render their own window but must not clobber
                             * the shared root pixmap with just their slice. */
-    Pixmap root_pixmap;  /* Pixmap set on root window for pseudo-transparency */
+    Pixmap root_pixmap;  /* Pixmap set on root window for pseudo-transparency.
+                          * Whether it is *advertised* is backend state, not surface
+                          * state: see x11_backend_data_t.published_root_pixmap.
+                          * Until the first commit fills it, it holds whatever
+                          * XCreatePixmap handed back, which is undefined — so it is
+                          * not advertised at create time. */
     GC gc;               /* Graphics context for copying to pixmap */
     XImage *ximage;      /* XImage for transferring OpenGL pixels to pixmap */
     unsigned char *pixel_buffer;  /* Buffer for glReadPixels */
@@ -116,23 +169,240 @@ static bool x11_init_atoms(x11_backend_data_t *backend) {
     backend->atom_net_wm_state_skip_taskbar = XInternAtom(dpy, "_NET_WM_STATE_SKIP_TASKBAR", False);
     backend->atom_net_wm_state_skip_pager = XInternAtom(dpy, "_NET_WM_STATE_SKIP_PAGER", False);
 
+    /* Desktop placement + name, for the managed path. */
+    backend->atom_net_wm_desktop = XInternAtom(dpy, "_NET_WM_DESKTOP", False);
+    backend->atom_net_wm_name = XInternAtom(dpy, "_NET_WM_NAME", False);
+    backend->atom_utf8_string = XInternAtom(dpy, "UTF8_STRING", False);
+
+    /* Interned once, not per-probe: the probe re-runs on every root
+     * PropertyNotify naming these atoms. */
+    backend->atom_net_supporting_wm_check =
+        XInternAtom(dpy, "_NET_SUPPORTING_WM_CHECK", False);
+    backend->atom_net_supported = XInternAtom(dpy, "_NET_SUPPORTED", False);
+
+    /* Root-pixmap advertisement. Interned here, with the rest, rather than being
+     * cached in a function-static: atom IDs are per-server, and the backend is
+     * re-initialised against a fresh Display if the X server restarts. */
+    backend->atom_xrootpmap_id = XInternAtom(dpy, "_XROOTPMAP_ID", False);
+    backend->atom_esetroot_pmap_id = XInternAtom(dpy, "ESETROOT_PMAP_ID", False);
+
     return true;
 }
 
-/* Declare a wallpaper window as the desktop, before it is mapped.
+/* Defined with its publishing counterpart, below the commit path. Used by both
+ * the surface-destroy path and backend cleanup. */
+static void x11_unpublish_root_pixmap(x11_backend_data_t *backend);
+
+/* ============================================================================
+ * WINDOW MANAGER DETECTION
+ * ============================================================================ */
+
+/* XGetWindowProperty on the window named by a stale _NET_SUPPORTING_WM_CHECK
+ * raises BadWindow, and Xlib's default error handler terminates the process.
+ * Swallow errors for the duration of the probe.
  *
- * EWMH requires _NET_WM_WINDOW_TYPE to be set before the window is mapped, and a
- * client may only set _NET_WM_STATE directly while the window is unmapped; once
- * mapped, state changes must go through the window manager via a _NET_WM_STATE
- * client message.
+ * THREADING CONSTRAINT: XSetErrorHandler is process-global, not per-Display.
+ * Xlib keeps exactly one handler pointer for the whole process, so the
+ * save/install/restore dance below is only safe because nothing else in the
+ * process can be making X requests concurrently: compositor_backend_init()
+ * (and hence every call to this probe that runs at startup) completes before
+ * the first pthread_create() in the codebase. The re-probe on the no-WM -> WM
+ * edge runs later, but on the event-loop thread, which is the only thread that
+ * touches this Display.
  *
- * The wallpaper windows are override-redirect, so no window manager reads these
- * properties today and setting them changes nothing about how the window is
- * stacked or drawn. They are set because they are the properties the window is
- * meant to carry: the atoms are already interned for exactly this purpose, and
- * anything that does inspect the window (a pager, a screenshot tool, a future
- * managed-window path) then finds the correct hints rather than none at all. */
-static void x11_set_wallpaper_properties(x11_backend_data_t *backend, Window window) {
+ * If a future change spawns a thread that makes X requests, or moves backend
+ * init after thread spawn, this becomes a race: the other thread's errors would
+ * be swallowed for the probe's duration, and its own handler could be clobbered.
+ * Either keep that invariant or move to a per-probe Display connection. */
+static bool x11_probe_error;
+
+static int x11_probe_error_handler(Display *dpy, XErrorEvent *err) {
+    (void)dpy;
+    (void)err;
+    x11_probe_error = true;
+    return 0;
+}
+
+/* Read one XA_WINDOW-typed property naming a single window. Returns true if the
+ * property is present with the expected type/format/count, and writes the window
+ * it names to *out. */
+static bool x11_read_window_prop(Display *dpy, Window target, Atom prop_atom,
+                                 unsigned long *out) {
+    Atom actual_type = None;
+    int actual_format = 0;
+    unsigned long nitems = 0, bytes_after = 0;
+    unsigned char *prop = NULL;
+
+    if (XGetWindowProperty(dpy, target, prop_atom, 0, 1, False, XA_WINDOW,
+                           &actual_type, &actual_format, &nitems, &bytes_after,
+                           &prop) != Success) {
+        return false;
+    }
+    if (actual_type != XA_WINDOW || actual_format != 32 || nitems != 1 || !prop) {
+        if (prop) XFree(prop);
+        return false;
+    }
+
+    *out = (unsigned long)*(Window *)prop;
+    XFree(prop);
+    return true;
+}
+
+/* Fill obs->supported_prop_valid / obs->desktop_in_supported from the root's
+ * _NET_SUPPORTED. A root property read cannot raise BadWindow, so this needs no
+ * error handler. Bounded read: 4096 32-bit items is far beyond any real WM's
+ * list (metacity's is under a hundred). */
+static void x11_read_supported(x11_backend_data_t *backend, x11_wm_check_obs_t *obs) {
+    Atom actual_type = None;
+    int actual_format = 0;
+    unsigned long nitems = 0, bytes_after = 0;
+    unsigned char *prop = NULL;
+
+    if (XGetWindowProperty(backend->x_display, backend->root_window,
+                           backend->atom_net_supported, 0, 4096, False, XA_ATOM,
+                           &actual_type, &actual_format, &nitems, &bytes_after,
+                           &prop) != Success) {
+        return;
+    }
+    if (actual_type != XA_ATOM || actual_format != 32 || nitems == 0 || !prop) {
+        if (prop) XFree(prop);
+        return;
+    }
+
+    obs->supported_prop_valid = true;
+    Atom *atoms = (Atom *)prop;
+    for (unsigned long i = 0; i < nitems; i++) {
+        if (atoms[i] == backend->atom_net_wm_window_type_desktop) {
+            obs->desktop_in_supported = true;
+            break;
+        }
+    }
+    XFree(prop);
+}
+
+/* True if a window manager we should hand a managed window to owns the screen:
+ * a live EWMH WM (two-step _NET_SUPPORTING_WM_CHECK handshake, EWMH 1.5) that
+ * advertises _NET_WM_WINDOW_TYPE_DESKTOP in _NET_SUPPORTED.
+ *
+ * This function gathers the facts from the X server; the decisions made from
+ * them are x11_ewmh_wm_check_decide() / x11_ewmh_wm_manages_desktop(), in
+ * x11_wm_detect.c, so they can be unit-tested without an X server. Also records
+ * backend->wm_alive (liveness regardless of desktop support) for logging. */
+static bool x11_ewmh_wm_present(x11_backend_data_t *backend) {
+    Display *dpy = backend->x_display;
+    Atom check = backend->atom_net_supporting_wm_check;
+
+    x11_wm_check_obs_t obs;
+    memset(&obs, 0, sizeof(obs));
+
+    obs.root_prop_valid =
+        x11_read_window_prop(dpy, backend->root_window, check, &obs.root_names);
+
+    /* Only the second read can touch a window that may not exist, so only it
+     * needs the error handler. */
+    bool present = false;
+    if (obs.root_prop_valid && obs.root_names != 0) {
+        x11_read_supported(backend, &obs);
+
+        x11_probe_error = false;
+        XErrorHandler prev = XSetErrorHandler(x11_probe_error_handler);
+
+        obs.child_prop_valid =
+            x11_read_window_prop(dpy, (Window)obs.root_names, check, &obs.child_names);
+
+        obs.x_error = x11_probe_error;
+        present = x11_ewmh_wm_manages_desktop(&obs);
+
+        /* Watch the WM's check window die. A WM that is killed outright leaves the
+         * root property behind, so its death produces no PropertyNotify — this
+         * DestroyNotify is the only event that tells us. Selecting input on
+         * another client's window is fine (StructureNotify is not exclusive); it
+         * races with the window being destroyed, hence the error handler, which is
+         * still installed here.
+         *
+         * XSelectInput REPLACES this client's mask on the window. If a broken WM
+         * ever named the root as its check window, a bare StructureNotifyMask here
+         * would drop the PropertyChangeMask selected at init and blind the WM
+         * tracker for the rest of the session — so keep it in that case. */
+        if (present) {
+            backend->wm_check_window = (Window)obs.root_names;
+            long mask = StructureNotifyMask;
+            if (backend->wm_check_window == backend->root_window) {
+                mask |= PropertyChangeMask;
+            }
+            XSelectInput(dpy, backend->wm_check_window, mask);
+        }
+
+        XSync(dpy, False);  /* Flush any BadWindow before restoring the handler. */
+        XSetErrorHandler(prev);
+
+        /* A BadWindow at any point in the probe — including XSelectInput racing
+         * the check window's destruction — means the WM is already gone. Fold it
+         * into the observations and re-decide, so present and wm_alive below are
+         * derived from one consistent set of facts. */
+        obs.x_error = obs.x_error || x11_probe_error;
+        present = x11_ewmh_wm_manages_desktop(&obs);
+    }
+
+    backend->wm_alive = x11_ewmh_wm_check_decide(&obs);
+    if (!present) {
+        backend->wm_check_window = None;
+    }
+    return present;
+}
+
+/* Decide how the per-monitor wallpaper windows are created, and record whether
+ * the env var pinned that choice (which disables the later heal).
+ *
+ * NEOWALL_X11_OVERRIDE_REDIRECT=1 forces override-redirect, =0 forces a managed
+ * window, as an escape hatch for WMs that mis-handle the auto-detected choice.
+ * Any other value is a mistake and is reported rather than silently ignored. */
+static bool x11_use_override_redirect(x11_backend_data_t *backend) {
+    const char *env = getenv("NEOWALL_X11_OVERRIDE_REDIRECT");
+    x11_or_env_t mode = x11_or_env_parse(env);
+
+    if (mode == X11_OR_ENV_INVALID) {
+        log_warn("X11: NEOWALL_X11_OVERRIDE_REDIRECT=\"%s\" is not recognised "
+                 "(expected \"0\" for a managed window or \"1\" for "
+                 "override-redirect) - ignoring it and auto-detecting", env);
+    }
+
+    backend->or_env_forced = x11_or_env_is_forced(mode);
+    backend->wm_present = x11_ewmh_wm_present(backend);
+
+    bool override_redirect = x11_or_decide(mode, backend->wm_present);
+
+    if (backend->or_env_forced) {
+        log_info("X11: NEOWALL_X11_OVERRIDE_REDIRECT=%s, forcing %s wallpaper window",
+                 env, override_redirect ? "override-redirect" : "managed");
+    } else if (backend->wm_present) {
+        log_info("X11: EWMH window manager with _NET_WM_WINDOW_TYPE_DESKTOP "
+                 "support detected - using managed wallpaper windows");
+    } else if (backend->wm_alive) {
+        log_info("X11: EWMH window manager detected, but its _NET_SUPPORTED does "
+                 "not advertise _NET_WM_WINDOW_TYPE_DESKTOP - using "
+                 "override-redirect wallpaper windows "
+                 "(NEOWALL_X11_OVERRIDE_REDIRECT=0 forces managed)");
+    } else {
+        log_info("X11: no EWMH window manager - using override-redirect wallpaper "
+                 "windows (will switch to managed if one appears)");
+    }
+
+    return override_redirect;
+}
+
+/* Declare the wallpaper window as the desktop, before it is mapped. EWMH requires
+ * _NET_WM_WINDOW_TYPE to be set before the window is mapped, and the client may
+ * only set _NET_WM_STATE directly while the window is unmapped; once mapped, state
+ * changes must go through the WM via a _NET_WM_STATE client message.
+ *
+ * Everything here is set on both the managed and the override-redirect path. A
+ * WM does not read properties off an override-redirect window, so on that path
+ * they are inert — but they are also free, and setting them unconditionally
+ * means the heal path (x11_recreate_surfaces) has one window-setup path to get
+ * right instead of two. */
+static void x11_set_wallpaper_properties(x11_backend_data_t *backend, Window window,
+                                         int pos_x, int pos_y, int width, int height) {
     Display *dpy = backend->x_display;
 
     XChangeProperty(dpy, window, backend->atom_net_wm_window_type, XA_ATOM, 32,
@@ -148,6 +418,61 @@ static void x11_set_wallpaper_properties(x11_backend_data_t *backend, Window win
     XChangeProperty(dpy, window, backend->atom_net_wm_state, XA_ATOM, 32,
                     PropModeReplace, (unsigned char *)states,
                     (int)(sizeof(states) / sizeof(states[0])));
+
+    /* EWMH 5.5 / 9.2: a desktop window belongs on every desktop, which is what
+     * 0xFFFFFFFF means. _NET_WM_STATE_STICKY above is not the same thing — it
+     * means "fixed relative to the viewport", i.e. it does not scroll with a
+     * large desktop, and says nothing about which desktops the window is on. A
+     * format-32 property is passed to Xlib as an array of long. */
+    unsigned long all_desktops = 0xFFFFFFFFUL;
+    XChangeProperty(dpy, window, backend->atom_net_wm_desktop, XA_CARDINAL, 32,
+                    PropModeReplace, (unsigned char *)&all_desktops, 1);
+
+    /* ICCCM 4.1.2.5: WM_CLASS "must be present when the window leaves the
+     * Withdrawn state". An override-redirect window is never managed, so it was
+     * exempt; a managed wallpaper window is not. This is also the handle a user
+     * needs to write a WM rule against us if our stacking misbehaves on their
+     * WM (i3 `for_window [class="NeoWall"]`, KWin window rules, openbox
+     * `<application class="NeoWall">`). */
+    XClassHint class_hint = {
+        .res_name = (char *)"neowall",   /* instance name */
+        .res_class = (char *)"NeoWall",  /* class name */
+    };
+    XSetClassHint(dpy, window, &class_hint);
+
+    /* WM_NAME (ICCCM, latin-1) and _NET_WM_NAME (EWMH, UTF-8). EWMH says a WM
+     * must prefer _NET_WM_NAME where both are present; pagers and `xprop` read
+     * either, so set both. */
+    static const char wm_name[] = "NeoWall Wallpaper";
+    XStoreName(dpy, window, wm_name);
+    XChangeProperty(dpy, window, backend->atom_net_wm_name, backend->atom_utf8_string,
+                    8, PropModeReplace, (const unsigned char *)wm_name,
+                    (int)(sizeof(wm_name) - 1));
+
+    /* ICCCM 4.1.2.3: for a managed window the geometry passed to XCreateWindow is
+     * only a request, and without PPosition the WM is free to place the window by
+     * its own policy. We create one window per monitor at that monitor's origin,
+     * so being placed anywhere else puts the wrong wallpaper on the wrong screen.
+     * PPosition/PSize say the position and size are ours, not the WM's.
+     *
+     * Deliberately no PMinSize/PMaxSize: the window is resized on RandR changes
+     * (x11_configure_surface), and pinning min == max here would leave stale hints
+     * fighting that. */
+    XSizeHints size_hints;
+    memset(&size_hints, 0, sizeof(size_hints));
+    size_hints.flags = PPosition | PSize;
+    size_hints.x = pos_x;
+    size_hints.y = pos_y;
+    size_hints.width = width;
+    size_hints.height = height;
+    XSetWMNormalHints(dpy, window, &size_hints);
+
+    /* input=False: the wallpaper must never take keyboard focus from real apps. */
+    XWMHints wm_hints;
+    memset(&wm_hints, 0, sizeof(wm_hints));
+    wm_hints.flags = InputHint;
+    wm_hints.input = False;
+    XSetWMHints(dpy, window, &wm_hints);
 }
 
 /* ============================================================================
@@ -247,6 +572,21 @@ static void *x11_backend_init(struct neowall_state *state) {
     /* Initialize XRandR */
     x11_init_xrandr(backend);
 
+    /* Watch the root for _NET_SUPPORTING_WM_CHECK appearing or changing, so a
+     * window manager that starts *after* us is noticed. A wallpaper daemon is
+     * autostarted at login and routinely wins that race; probing once at init and
+     * never looking again would leave us override-redirect for the whole session,
+     * painting over every window the WM later maps.
+     *
+     * No other code in the process selects a core event mask on the root
+     * (XRRSelectInput sets the RandR extension's own mask, which is separate), so
+     * this does not clobber anyone else's selection. */
+    XSelectInput(backend->x_display, backend->root_window, PropertyChangeMask);
+
+    /* Probe the WM; every per-monitor window is created the same way. Re-run on
+     * the root PropertyNotify above (see x11_recheck_wm). */
+    backend->override_redirect = x11_use_override_redirect(backend);
+
     backend->initialized = true;
 
     log_info("X11 backend initialized successfully");
@@ -265,6 +605,14 @@ static void x11_backend_cleanup(void *backend_data) {
     log_info("Cleaning up X11 backend");
 
     if (backend->x_display) {
+        /* Shutdown does not tear surfaces down one by one — main() cleans up EGL
+         * and then closes the display — so this is the only place the root-pixmap
+         * advertisement gets withdrawn on exit. Without it, closing the connection
+         * destroys the pixmap (X protocol: a client's resources are freed at
+         * connection close unless the close-down mode retains them) and leaves
+         * _XROOTPMAP_ID / ESETROOT_PMAP_ID naming a dead XID for the next reader. */
+        x11_unpublish_root_pixmap(backend);
+
         XCloseDisplay(backend->x_display);
         backend->x_display = NULL;
     }
@@ -356,7 +704,7 @@ static struct compositor_surface *x11_create_surface(void *backend_data,
 
     /* Create a fullscreen window at the bottom of the stack */
     XSetWindowAttributes attrs;
-    attrs.override_redirect = True;  /* Bypass WM completely */
+    attrs.override_redirect = backend->override_redirect ? True : False;
     attrs.background_pixel = BlackPixel(backend->x_display, backend->screen);
     attrs.border_pixel = 0;
     attrs.event_mask = ExposureMask | StructureNotifyMask |
@@ -382,28 +730,35 @@ static struct compositor_surface *x11_create_surface(void *backend_data,
         return NULL;
     }
 
-    /* Must precede XMapWindow: EWMH hints are read at map time. */
-    x11_set_wallpaper_properties(backend, surf_data->x_window);
+    /* Must precede XMapWindow: EWMH hints on an already-mapped window are not
+     * read by the WM at map time. */
+    x11_set_wallpaper_properties(backend, surf_data->x_window,
+                                 pos_x, pos_y, width, height);
 
     /* Map and lower the window to bottom of stack */
     XMapWindow(backend->x_display, surf_data->x_window);
     XLowerWindow(backend->x_display, surf_data->x_window);
 
-    /* Raise all other windows above this one */
-    Window root_return, parent_return;
-    Window *children = NULL;
-    unsigned int nchildren = 0;
+    /* Only meaningful without a WM. A managed window may be reparented into a
+     * frame, so the root's children are the WM's frames - raising them all would
+     * fight the WM's own stacking of the desktop window. */
+    if (backend->override_redirect) {
+        /* Raise all other windows above this one */
+        Window root_return, parent_return;
+        Window *children = NULL;
+        unsigned int nchildren = 0;
 
-    if (XQueryTree(backend->x_display, backend->root_window, &root_return,
-                   &parent_return, &children, &nchildren)) {
-        /* Raise all windows except our wallpaper window */
-        for (unsigned int i = 0; i < nchildren; i++) {
-            if (children[i] != surf_data->x_window) {
-                XRaiseWindow(backend->x_display, children[i]);
+        if (XQueryTree(backend->x_display, backend->root_window, &root_return,
+                       &parent_return, &children, &nchildren)) {
+            /* Raise all windows except our wallpaper window */
+            for (unsigned int i = 0; i < nchildren; i++) {
+                if (children[i] != surf_data->x_window) {
+                    XRaiseWindow(backend->x_display, children[i]);
+                }
             }
-        }
-        if (children) {
-            XFree(children);
+            if (children) {
+                XFree(children);
+            }
         }
     }
 
@@ -413,28 +768,18 @@ static struct compositor_surface *x11_create_surface(void *backend_data,
      * don't paint just their slice onto the whole root. */
     surf_data->owns_root_pixmap = (pos_x == 0 && pos_y == 0);
 
-    if (surf_data->owns_root_pixmap) {
-        /* Set the pixmap as root window background */
-        XSetWindowBackgroundPixmap(backend->x_display, backend->root_window, surf_data->root_pixmap);
-        XClearWindow(backend->x_display, backend->root_window);
-
-        /* Set root window properties for pseudo-transparency apps (Conky, etc) */
-        Atom prop_root = XInternAtom(backend->x_display, "_XROOTPMAP_ID", False);
-        Atom prop_esetroot = XInternAtom(backend->x_display, "ESETROOT_PMAP_ID", False);
-        XChangeProperty(backend->x_display, backend->root_window, prop_root, XA_PIXMAP, 32,
-                       PropModeReplace, (unsigned char *)&surf_data->root_pixmap, 1);
-        XChangeProperty(backend->x_display, backend->root_window, prop_esetroot, XA_PIXMAP, 32,
-                       PropModeReplace, (unsigned char *)&surf_data->root_pixmap, 1);
-
-        /* Send PropertyNotify event to notify apps like Conky that background changed */
-        XEvent event;
-        memset(&event, 0, sizeof(event));
-        event.type = PropertyNotify;
-        event.xproperty.window = backend->root_window;
-        event.xproperty.atom = prop_root;
-        event.xproperty.state = PropertyNewValue;
-        XSendEvent(backend->x_display, backend->root_window, False, PropertyChangeMask, &event);
-    }
+    /* The pixmap is deliberately NOT made the root's background here. The X
+     * protocol leaves the initial contents of a pixmap undefined (XCreatePixmap
+     * does not clear it), so publishing it now and clearing the root would put
+     * undefined server memory on the screen.
+     *
+     * That matters because the root's background is exactly what is visible while
+     * the wallpaper window is not: on the managed path the window is mapped by the
+     * window manager, in another process, so there is a gap between creating the
+     * window and it becoming viewable. Publishing is therefore deferred to the
+     * first x11_commit_surface that has actually rendered into the pixmap
+     * (x11_publish_root_pixmap). Until then the root keeps the background it
+     * already had. */
 
     XFlush(backend->x_display);
 
@@ -487,6 +832,12 @@ static void x11_destroy_surface(struct compositor_surface *surface) {
                 XFreeGC(backend->x_display, surf_data->gc);
             }
             if (surf_data->root_pixmap) {
+                /* Withdraw the advertisement first: after XFreePixmap the XID is
+                 * invalid, and nothing republishes until the replacement surface's
+                 * first rendered commit. */
+                if (backend->published_root_pixmap == surf_data->root_pixmap) {
+                    x11_unpublish_root_pixmap(backend);
+                }
                 XFreePixmap(backend->x_display, surf_data->root_pixmap);
             }
             if (surf_data->ximage) {
@@ -522,9 +873,12 @@ static bool x11_configure_surface(struct compositor_surface *surface,
     if (!surface || !config) return false;
 
     x11_surface_data_t *surf_data = surface->backend_data;
-    x11_backend_data_t *backend = (x11_backend_data_t *)surface->backend;
+    /* surface->backend is the compositor_backend wrapper (compositor_surface.c
+     * re-points it after create_surface returns); the X11 state is its ->data. */
+    x11_backend_data_t *backend =
+        surface->backend ? (x11_backend_data_t *)surface->backend->data : NULL;
 
-    if (!surf_data || !backend) return false;
+    if (!surf_data || !backend || !backend->x_display) return false;
 
     log_debug("Configuring X11 surface");
 
@@ -707,6 +1061,106 @@ static bool x11_handle_events(x11_backend_data_t *backend) {
  * COMMIT SURFACE
  * ============================================================================ */
 
+/* Does the root property `prop` still name the pixmap we put there? */
+static bool x11_root_prop_names(x11_backend_data_t *backend, Atom prop, Pixmap pixmap) {
+    Atom type;
+    int format;
+    unsigned long n, rem;
+    unsigned char *data = NULL;
+
+    if (XGetWindowProperty(backend->x_display, backend->root_window, prop, 0, 1,
+                           False, XA_PIXMAP, &type, &format, &n, &rem,
+                           &data) != Success || !data) {
+        return false;
+    }
+    bool match = (type == XA_PIXMAP && format == 32 && n == 1 &&
+                  *(Pixmap *)(void *)data == pixmap);
+    XFree(data);
+    return match;
+}
+
+/* Withdraw the root-pixmap advertisement before the pixmap it names is freed.
+ *
+ * XFreePixmap invalidates the XID at the protocol level immediately, so any
+ * client that reads _XROOTPMAP_ID / ESETROOT_PMAP_ID after the free and before
+ * the replacement surface republishes gets a dangling drawable. The window in
+ * which that can happen is new: this backend now destroys and rebuilds its
+ * windows mid-session (WM appears, WM dies), where before it created them once.
+ *
+ * Deleting the properties is the right shape rather than deferring the free
+ * until the replacement has published, because:
+ *   - "no root pixmap" is a state every pseudo-transparency client already
+ *     handles: it is what the root looks like before any wallpaper setter has
+ *     run. A dangling XID is not — it is a BadDrawable on the client's next
+ *     XCopyArea, which is a class of bug the client cannot even see coming.
+ *   - deferring the free has no safe end: if the replacement surface never
+ *     commits (recreate failed, or we are shutting down) the pixmap is leaked in
+ *     the server for the life of the connection, and the properties still name
+ *     it. It trades a short-lived dangling XID for a permanent one plus a leak.
+ *
+ * The root's *background* is unaffected: the server holds its own reference to a
+ * window's background-pixmap, so freeing the pixmap does not blank the root. (X
+ * protocol, ChangeWindowAttributes: the background pixmap may be freed
+ * immediately if no further explicit references to it are to be made.)
+ *
+ * Only deletes properties that still name our own pixmap, so a wallpaper setter
+ * that took the root over while we were running keeps its advertisement. */
+static void x11_unpublish_root_pixmap(x11_backend_data_t *backend) {
+    if (!backend->x_display || !backend->published_root_pixmap) {
+        return;
+    }
+
+    Display *dpy = backend->x_display;
+    Pixmap ours = backend->published_root_pixmap;
+
+    if (x11_root_prop_names(backend, backend->atom_xrootpmap_id, ours)) {
+        XDeleteProperty(dpy, backend->root_window, backend->atom_xrootpmap_id);
+    }
+    if (x11_root_prop_names(backend, backend->atom_esetroot_pmap_id, ours)) {
+        XDeleteProperty(dpy, backend->root_window, backend->atom_esetroot_pmap_id);
+    }
+    backend->published_root_pixmap = 0;
+
+    /* Requests are processed in order on this connection, so the deletes (and
+     * the PropertyNotify they generate) reach the server before the caller's
+     * XFreePixmap. Flush so that holds even if we are on our way out. */
+    XFlush(dpy);
+}
+
+/* Make the (now filled) root pixmap the root window's background and tell
+ * pseudo-transparency clients about it.
+ *
+ * _XROOTPMAP_ID / ESETROOT_PMAP_ID name the pixmap for clients like Conky. They
+ * are (re)written whenever the advertised pixmap ID changes — which it does on
+ * every surface recreation, since each new surface gets a fresh XCreatePixmap —
+ * so a client that reads them does not end up holding a stale ID. */
+static void x11_publish_root_pixmap(x11_backend_data_t *backend,
+                                    x11_surface_data_t *surf_data) {
+    Display *dpy = backend->x_display;
+
+    XSetWindowBackgroundPixmap(dpy, backend->root_window, surf_data->root_pixmap);
+    XClearWindow(dpy, backend->root_window);
+
+    if (backend->published_root_pixmap != surf_data->root_pixmap) {
+        XChangeProperty(dpy, backend->root_window, backend->atom_xrootpmap_id,
+                        XA_PIXMAP, 32, PropModeReplace,
+                        (unsigned char *)&surf_data->root_pixmap, 1);
+        XChangeProperty(dpy, backend->root_window, backend->atom_esetroot_pmap_id,
+                        XA_PIXMAP, 32, PropModeReplace,
+                        (unsigned char *)&surf_data->root_pixmap, 1);
+        backend->published_root_pixmap = surf_data->root_pixmap;
+    }
+
+    /* Poke Conky and friends: the background changed. */
+    XEvent event;
+    memset(&event, 0, sizeof(event));
+    event.type = PropertyNotify;
+    event.xproperty.window = backend->root_window;
+    event.xproperty.atom = backend->atom_xrootpmap_id;
+    event.xproperty.state = PropertyNewValue;
+    XSendEvent(dpy, backend->root_window, False, PropertyChangeMask, &event);
+}
+
 static void x11_commit_surface(struct compositor_surface *surface) {
     if (!surface) return;
 
@@ -765,22 +1219,10 @@ static void x11_commit_surface(struct compositor_surface *surface) {
             XPutImage(backend->x_display, surf_data->root_pixmap, surf_data->gc,
                      surf_data->ximage, 0, 0, 0, 0, surface->width, surface->height);
 
-            /* Update root window background */
-            XSetWindowBackgroundPixmap(backend->x_display, backend->root_window, surf_data->root_pixmap);
-            XClearWindow(backend->x_display, backend->root_window);
-
-            /* Notify apps like Conky that background changed */
-            static Atom prop_root = 0;
-            if (!prop_root) {
-                prop_root = XInternAtom(backend->x_display, "_XROOTPMAP_ID", False);
-            }
-            XEvent event;
-            memset(&event, 0, sizeof(event));
-            event.type = PropertyNotify;
-            event.xproperty.window = backend->root_window;
-            event.xproperty.atom = prop_root;
-            event.xproperty.state = PropertyNewValue;
-            XSendEvent(backend->x_display, backend->root_window, False, PropertyChangeMask, &event);
+            /* The pixmap now holds real rendered content, so it is safe to be the
+             * root's background. On the first commit after a surface is created this
+             * is what publishes it (x11_create_surface deliberately does not). */
+            x11_publish_root_pixmap(backend, surf_data);
         }
     }
 
@@ -804,9 +1246,8 @@ static bool x11_create_egl_window(struct compositor_surface *surface,
     if (!surface) return false;
 
     x11_surface_data_t *surf_data = surface->backend_data;
-    x11_backend_data_t *backend = (x11_backend_data_t *)surface->backend;
 
-    if (!surf_data || !backend) return false;
+    if (!surf_data || !surface->backend) return false;
 
     log_debug("Creating EGL surface for X11 window");
 
@@ -1317,6 +1758,190 @@ static void x11_reconcile_outputs(x11_backend_data_t *backend) {
 
 
 /* ============================================================================
+ * WM APPEARED LATE (heal override-redirect -> managed)
+ * ============================================================================ */
+
+/* Destroy and rebuild every wallpaper window with the current
+ * backend->override_redirect.
+ *
+ * The window has to be *recreated*, not re-propertied: override_redirect is a
+ * window attribute fixed at XCreateWindow time. XChangeWindowAttributes can set
+ * it on a mapped window, but the WM decided whether to manage the window when it
+ * saw the MapRequest (or, for an override-redirect window, when it saw the
+ * MapNotify it was told to ignore), so flipping the attribute afterwards does not
+ * retroactively hand the window to the WM.
+ *
+ * The EGL *context* is a single shared state->egl_context, not one per surface;
+ * only the EGLSurface is tied to the native window. So destroying the EGLSurface
+ * and the X window and rebuilding both keeps every GL object — textures, shader
+ * programs, VAOs — alive in the context. No re-upload, no re-compile, and hence
+ * no call to output_init_render() here (unlike the hotplug path, which is
+ * building a brand-new output_state that has no render state yet).
+ *
+ * Runs on the event-loop thread, which owns the EGL context, so the GL work is
+ * safe inline. Same thread and same teardown order as the hotplug reconcile.
+ * Caller must NOT hold output_list_lock. */
+static void x11_recreate_surfaces(x11_backend_data_t *backend) {
+    struct neowall_state *state = backend->state;
+    if (!state) return;
+
+    /* Snapshot the list under the read lock, with a ref on each output; the
+     * rebuild below runs without the lock. */
+    struct output_state *outs[MAX_OUTPUTS];
+    int n = 0;
+    pthread_rwlock_rdlock(&state->output_list_lock);
+    for (struct output_state *o = state->outputs; o && n < MAX_OUTPUTS; o = o->next) {
+        output_ref(o);
+        outs[n++] = o;
+    }
+    pthread_rwlock_unlock(&state->output_list_lock);
+
+    for (int i = 0; i < n; i++) {
+        struct output_state *o = outs[i];
+
+        /* Release the EGL surface from this thread before destroying it. */
+        egl_core_make_current(state, NULL);
+
+        if (o->compositor_surface) {
+            if (o->compositor_surface->egl_surface != EGL_NO_SURFACE) {
+                compositor_surface_destroy_egl(o->compositor_surface, state->egl_display);
+            }
+            compositor_surface_destroy(o->compositor_surface);
+            o->compositor_surface = NULL;
+        }
+
+        if (!x11_attach_surface(state, o) ||
+            !output_create_egl_surface(o) ||
+            !egl_core_make_current(state, o)) {
+            log_error("X11: failed to recreate wallpaper window for %s",
+                      o->connector_name);
+            output_unref(o);
+            continue;
+        }
+
+        atomic_store_explicit(&o->needs_redraw, true, memory_order_release);
+        log_info("X11: wallpaper window for %s recreated as %s",
+                 o->connector_name,
+                 backend->override_redirect ? "override-redirect" : "managed");
+        output_unref(o);
+    }
+}
+
+/* Mark the output that owns an X window for redraw.
+ *
+ * An X11 window does not retain its contents: when it is obscured, restacked,
+ * reparented into (or out of) a WM frame, or remapped, whatever was drawn is
+ * discarded and the server sends Expose. A shader wallpaper repaints every frame
+ * anyway, but a static image is drawn once and then needs_redraw is cleared
+ * (eventloop.c), so without this the window stays black for the rest of the
+ * session. Observed on Xvfb: a static wallpaper goes black the moment the WM
+ * takes the window over, and again when the WM dies. */
+static void x11_mark_window_dirty(x11_backend_data_t *backend, Window window) {
+    struct neowall_state *state = backend->state;
+    if (!state) return;
+
+    pthread_rwlock_rdlock(&state->output_list_lock);
+    for (struct output_state *o = state->outputs; o; o = o->next) {
+        if (!o->compositor_surface) continue;
+        x11_surface_data_t *sd = o->compositor_surface->backend_data;
+        if (sd && sd->x_window == window) {
+            atomic_store_explicit(&o->needs_redraw, true, memory_order_release);
+            break;
+        }
+    }
+    pthread_rwlock_unlock(&state->output_list_lock);
+}
+
+/* Act on the current WM state: rebuild the wallpaper windows if the world no
+ * longer matches how they were created. Idempotent. */
+static void x11_apply_wm_transition(x11_backend_data_t *backend) {
+    x11_wm_action_t action = x11_wm_transition(backend->or_env_forced,
+                                               backend->override_redirect,
+                                               backend->wm_present);
+    switch (action) {
+        case X11_WM_ACTION_RECREATE_MANAGED:
+            log_info("X11: EWMH window manager appeared - recreating wallpaper "
+                     "windows as managed");
+            backend->override_redirect = false;
+            x11_recreate_surfaces(backend);
+            break;
+
+        case X11_WM_ACTION_RECREATE_OVERRIDE:
+            /* Observed on Xvfb (metacity, and a reparenting test WM): when the WM
+             * dies the wallpaper window's contents are lost, and with a static
+             * image needs_redraw has already been cleared, so nothing ever
+             * repaints it — the wallpaper stays black. Rebuilding on the
+             * override-redirect path restores the no-WM setup (XLowerWindow plus
+             * the raise-the-other-children loop) and repaints. */
+            log_info("X11: EWMH window manager went away - recreating wallpaper "
+                     "windows as override-redirect");
+            backend->override_redirect = true;
+            x11_recreate_surfaces(backend);
+            break;
+
+        case X11_WM_ACTION_NONE:
+        default:
+            break;
+    }
+}
+
+/* Re-run the WM probe after _NET_SUPPORTING_WM_CHECK changed on the root.
+ *
+ * The WM-appeared edge is acted on at once. The WM-went-away edge is deferred by
+ * X11_WM_GONE_DEBOUNCE_MS and re-checked in x11_dispatch_events, so a WM restart
+ * (which flaps the property down and straight back up) does not destroy and
+ * recreate every window twice. */
+static void x11_recheck_wm(x11_backend_data_t *backend) {
+    bool wm_now = x11_ewmh_wm_present(backend);
+
+    if (wm_now == backend->wm_present) {
+        return;  /* Property churn that does not change the answer. */
+    }
+    backend->wm_present = wm_now;
+
+    if (wm_now) {
+        /* A WM is up. Any pending "the WM is gone" action is stale — this is what
+         * makes a restart a no-op rather than two rebuilds. */
+        if (backend->wm_gone_deadline_ms) {
+            log_debug("X11: window manager came back before the rebuild deadline "
+                      "- cancelling");
+            backend->wm_gone_deadline_ms = 0;
+        }
+        x11_apply_wm_transition(backend);
+        return;
+    }
+
+    /* The WM is gone. Do not believe it yet. */
+    if (x11_wm_transition(backend->or_env_forced, backend->override_redirect,
+                          false) == X11_WM_ACTION_NONE) {
+        return;  /* Nothing would change anyway (forced, or already override-redirect). */
+    }
+    log_info("X11: EWMH window manager went away - waiting %d ms for a replacement",
+             X11_WM_GONE_DEBOUNCE_MS);
+    backend->wm_gone_deadline_ms = get_time_ms() + X11_WM_GONE_DEBOUNCE_MS;
+}
+
+/* Called every event-loop iteration. Fires the deferred WM-went-away rebuild once
+ * the debounce window has passed and no replacement WM has turned up. */
+static void x11_check_wm_gone_deadline(x11_backend_data_t *backend) {
+    if (!backend->wm_gone_deadline_ms ||
+        get_time_ms() < backend->wm_gone_deadline_ms) {
+        return;
+    }
+    backend->wm_gone_deadline_ms = 0;
+
+    /* Re-probe rather than trusting the earlier answer: a replacement WM may have
+     * come up without us having processed its PropertyNotify yet. */
+    backend->wm_present = x11_ewmh_wm_present(backend);
+    if (backend->wm_present) {
+        log_info("X11: a replacement window manager is running - keeping the "
+                 "managed wallpaper windows");
+        return;
+    }
+    x11_apply_wm_transition(backend);
+}
+
+/* ============================================================================
  * EVENT HANDLING OPERATIONS
  * ============================================================================ */
 
@@ -1340,6 +1965,24 @@ static bool x11_read_events(void *backend_data) {
     return true;
 }
 
+/* True if Xlib is already holding events for us.
+ *
+ * The event loop polls the connection fd, but Xlib does not hand events straight
+ * from the socket to poll(): it queues them in userspace, and any Xlib call that
+ * round-trips (XSync in the WM probe, XFlush in every commit) will drain the
+ * socket into that queue as a side effect. The fd then has nothing to report and
+ * poll() sleeps for its full timeout while the events sit in the queue.
+ *
+ * XPending() reports the queue length, flushing and reading the socket first if
+ * the queue is empty, so it is the right question to ask just before poll(). */
+static bool x11_has_pending_events(void *backend_data) {
+    x11_backend_data_t *backend = backend_data;
+    if (!backend || !backend->x_display) {
+        return false;
+    }
+    return XPending(backend->x_display) > 0;
+}
+
 static bool x11_dispatch_events(void *backend_data) {
     x11_backend_data_t *backend = backend_data;
     if (!backend || !backend->x_display) {
@@ -1347,6 +1990,7 @@ static bool x11_dispatch_events(void *backend_data) {
     }
 
     bool layout_changed = false;
+    bool wm_check_changed = false;
     bool mouse_on = backend->state &&
         atomic_load_explicit(&backend->state->mouse_interaction, memory_order_acquire);
 
@@ -1370,6 +2014,50 @@ static bool x11_dispatch_events(void *backend_data) {
                 }
                 break;
 
+            case Expose:
+                /* The window's contents were discarded and must be redrawn. Only
+                 * the last event of a burst matters (count == 0 = no more to come). */
+                if (event.xexpose.count == 0) {
+                    x11_mark_window_dirty(backend, event.xexpose.window);
+                }
+                break;
+
+            case PropertyNotify:
+                /* A window manager starting (or cleanly exiting) rewrites
+                 * _NET_SUPPORTING_WM_CHECK on the root. Coalesce a burst — a WM
+                 * start can touch the property more than once — into one re-probe
+                 * after the queue drains.
+                 *
+                 * The atom test is load-bearing, not just an optimisation:
+                 * x11_commit_surface XSendEvents a synthetic PropertyNotify for
+                 * _XROOTPMAP_ID to the root (to poke Conky) once a second, and now
+                 * that we select PropertyChangeMask on the root we receive our own
+                 * event back.
+                 *
+                 * _NET_SUPPORTED re-probes too: the managed choice requires
+                 * _NET_WM_WINDOW_TYPE_DESKTOP to be advertised there, and a
+                 * starting WM's write order between the two root properties is
+                 * not specified — keying on the handshake alone could read
+                 * _NET_SUPPORTED before the WM has set it and latch
+                 * override-redirect for the session. */
+                if (event.xproperty.window == backend->root_window &&
+                    (event.xproperty.atom == backend->atom_net_supporting_wm_check ||
+                     event.xproperty.atom == backend->atom_net_supported)) {
+                    wm_check_changed = true;
+                }
+                break;
+
+            case DestroyNotify:
+                /* The WM's _NET_SUPPORTING_WM_CHECK window has been destroyed. A
+                 * WM that is killed outright (kill -9, crash) does not clean up the
+                 * root property, so this is the only notification we get that it
+                 * has gone; waiting for a PropertyNotify would wait for ever. */
+                if (backend->wm_check_window != None &&
+                    event.xdestroywindow.window == backend->wm_check_window) {
+                    wm_check_changed = true;
+                }
+                break;
+
             default:
                 /* RRScreenChangeNotify: monitor layout changed. Coalesce a burst
                  * of notifies (mode set fires several) into one reconcile after
@@ -1382,6 +2070,14 @@ static bool x11_dispatch_events(void *backend_data) {
                 break;
         }
     }
+
+    if (wm_check_changed) {
+        x11_recheck_wm(backend);
+    }
+
+    /* Deferred WM-went-away rebuild. Checked every iteration (the event loop polls
+     * with at most a 1s timeout), not on a busy poll of the X server. */
+    x11_check_wm_gone_deadline(backend);
 
     if (layout_changed) {
         log_info("X11: monitor layout changed, reconciling outputs");
@@ -1456,6 +2152,7 @@ static const compositor_backend_ops_t x11_backend_ops = {
     /* Event handling operations */
     .get_fd = x11_get_fd,
     .prepare_events = x11_prepare_events,
+    .has_pending_events = x11_has_pending_events,
     .read_events = x11_read_events,
     .dispatch_events = x11_dispatch_events,
     .flush = x11_flush,

--- a/src/compositor/backends/x11/x11_occlusion.c
+++ b/src/compositor/backends/x11/x11_occlusion.c
@@ -41,6 +41,50 @@ static int check_counter = 0;
 /* Geometry of a fullscreen-marked window. */
 typedef x11_rect_t rect_t;
 
+/* A window named by _NET_CLIENT_LIST_STACKING can already be gone by the time we
+ * query it: the list is a snapshot, and windows are destroyed asynchronously.
+ * XGetWindowProperty/XGetGeometry on a window that no longer exists raises
+ * BadWindow, and Xlib's default error handler terminates the process.
+ *
+ * This is not hypothetical, and the window is not always someone else's. A window
+ * manager killed outright leaves _NET_CLIENT_LIST_STACKING behind on the root,
+ * still naming the wallpaper window it was managing; x11_core then rebuilds that
+ * window on the override-redirect path, destroying the old one. The next poll
+ * reads the dead WM's stale list and queries a window that is gone. Observed on
+ * Xvfb with metacity: kill -9 the WM and neowall exits with "BadWindow (invalid
+ * Window parameter)" about a second later, naming the destroyed wallpaper window.
+ *
+ * Only the "that window is gone" errors are tolerated silently: BadWindow from
+ * the property/translate requests, BadDrawable from XGetGeometry (its argument is
+ * a DRAWABLE, so a dead XID comes back as BadDrawable, not BadWindow). Any other
+ * error means something we did not predict — a wrong property type, a bad atom, a
+ * protocol bug — and reading it as "that window died, skip it" would hide it
+ * forever. Those are logged. The window is still skipped either way: whatever the
+ * error was, the reply we needed did not arrive, so the window cannot be counted
+ * as occluding anything.
+ *
+ * THREADING CONSTRAINT: XSetErrorHandler is process-global, not per-Display. The
+ * save/install/restore below is safe only because the occlusion poll runs on the
+ * event-loop thread, which is the only thread making X requests on this Display.
+ * This is the same invariant the WM probe in x11_core.c relies on; if either ever
+ * stops holding, both need their own Display connection instead. */
+static unsigned char occ_x_error;  /* Last X error code seen, 0 = none. */
+
+static int occ_error_handler(Display *dpy, XErrorEvent *err) {
+    occ_x_error = err->error_code;
+
+    if (err->error_code != BadWindow && err->error_code != BadDrawable) {
+        char text[128] = "";
+        XGetErrorText(dpy, err->error_code, text, sizeof(text));
+        log_error("x11_occlusion: unexpected X error while walking "
+                  "_NET_CLIENT_LIST_STACKING: %s (code %u, request %u.%u, "
+                  "resource 0x%lx) - skipping that window",
+                  text, err->error_code, err->request_code, err->minor_code,
+                  err->resourceid);
+    }
+    return 0;
+}
+
 static bool window_has_state(Display *dpy, Window win, Atom target) {
     Atom type;
     int format;
@@ -107,13 +151,29 @@ static void check_fullscreen_state(void) {
     int fs_count = 0;
     int fs_cap = 0;
 
+    /* Scoped to the per-window queries below, and only to those: the root property
+     * fetch above ran under the default handler, so a failure there is still fatal
+     * and visible rather than being read as "a window died". Every query below
+     * touches a window we do not own and cannot keep alive. */
+    XErrorHandler prev_handler = XSetErrorHandler(occ_error_handler);
+
     for (unsigned long i = 0; i < n; i++) {
-        if (!window_has_state(x_display, windows[i], atom_net_wm_state_fullscreen)) {
+        occ_x_error = 0;
+
+        bool is_fullscreen =
+            window_has_state(x_display, windows[i], atom_net_wm_state_fullscreen);
+        if (occ_x_error) {
+            continue;  /* Window died (silent), or something else went wrong and the
+                        * handler logged it. Either way there is no answer to use. */
+        }
+        if (!is_fullscreen) {
             continue;
         }
+
         int wx, wy, ww, wh;
-        if (!get_window_geometry(x_display, windows[i], &wx, &wy, &ww, &wh)) {
-            continue;
+        if (!get_window_geometry(x_display, windows[i], &wx, &wy, &ww, &wh) ||
+            occ_x_error) {
+            continue;  /* Window died under us — it cannot be occluding anything. */
         }
         if (fs_count == fs_cap) {
             int new_cap = fs_cap ? fs_cap * 2 : 8;
@@ -128,6 +188,10 @@ static void check_fullscreen_state(void) {
         }
         fs[fs_count++] = (rect_t){ wx, wy, ww, wh };
     }
+
+    XSync(x_display, False);  /* Deliver any straggling error before we un-install. */
+    XSetErrorHandler(prev_handler);
+
     XFree(data);
 
     /* Decide occlusion per output: each output is occluded when a fullscreen

--- a/src/compositor/backends/x11/x11_wm_detect.c
+++ b/src/compositor/backends/x11/x11_wm_detect.c
@@ -1,0 +1,84 @@
+/* Pure decision logic for the X11 backend's window-manager probe.
+ *
+ * No Xlib, no X server, no globals — see x11_wm_detect.h for why this is split
+ * out of x11_core.c. Unit-tested by tests/test_x11_wm_detect.c. */
+
+#include "x11_wm_detect.h"
+
+x11_or_env_t x11_or_env_parse(const char *value) {
+    if (!value) {
+        return X11_OR_ENV_UNSET;
+    }
+    if (value[0] == '1' && value[1] == '\0') {
+        return X11_OR_ENV_FORCE_ON;
+    }
+    if (value[0] == '0' && value[1] == '\0') {
+        return X11_OR_ENV_FORCE_OFF;
+    }
+    /* Present but not "0"/"1" — including "" — is a mistake, not a default. */
+    return X11_OR_ENV_INVALID;
+}
+
+bool x11_or_env_is_forced(x11_or_env_t env) {
+    return env == X11_OR_ENV_FORCE_ON || env == X11_OR_ENV_FORCE_OFF;
+}
+
+bool x11_ewmh_wm_check_decide(const x11_wm_check_obs_t *obs) {
+    if (!obs) {
+        return false;
+    }
+    /* No usable property on the root: no EWMH WM ever announced itself. */
+    if (!obs->root_prop_valid || obs->root_names == 0) {
+        return false;
+    }
+    /* The window the root names is gone (BadWindow) — a WM that exited without
+     * cleaning up. The root property is stale; there is no live WM. */
+    if (obs->x_error || !obs->child_prop_valid) {
+        return false;
+    }
+    /* The self-reference is the whole point of the two-step handshake. */
+    return obs->child_names == obs->root_names;
+}
+
+bool x11_ewmh_wm_manages_desktop(const x11_wm_check_obs_t *obs) {
+    if (!x11_ewmh_wm_check_decide(obs)) {
+        return false;
+    }
+    /* Only the WM's own advertisement proves it will stack a DESKTOP window
+     * (see x11_wm_detect.h); a live WM without it gets the override-redirect
+     * path, same as no WM at all. */
+    return obs->supported_prop_valid && obs->desktop_in_supported;
+}
+
+bool x11_or_decide(x11_or_env_t env, bool wm_present) {
+    switch (env) {
+        case X11_OR_ENV_FORCE_ON:
+            return true;
+        case X11_OR_ENV_FORCE_OFF:
+            return false;
+        case X11_OR_ENV_UNSET:
+        case X11_OR_ENV_INVALID:
+        default:
+            return !wm_present;
+    }
+}
+
+x11_wm_action_t x11_wm_transition(bool env_forced, bool current_override_redirect,
+                                  bool wm_present_now) {
+    /* The user pinned the choice; neither edge may override it. */
+    if (env_forced) {
+        return X11_WM_ACTION_NONE;
+    }
+    /* We are override-redirect and a WM is now running: it can stack the desktop
+     * for us, but only if the window is managed. */
+    if (current_override_redirect && wm_present_now) {
+        return X11_WM_ACTION_RECREATE_MANAGED;
+    }
+    /* We are managed and the WM is gone: nothing will stack or repaint the window
+     * any more, so go back to running it ourselves. */
+    if (!current_override_redirect && !wm_present_now) {
+        return X11_WM_ACTION_RECREATE_OVERRIDE;
+    }
+    /* Already in the right shape for the world as it is. */
+    return X11_WM_ACTION_NONE;
+}

--- a/src/compositor/backends/x11/x11_wm_detect.h
+++ b/src/compositor/backends/x11/x11_wm_detect.h
@@ -1,0 +1,150 @@
+#ifndef NEOWALL_X11_WM_DETECT_H
+#define NEOWALL_X11_WM_DETECT_H
+
+/* Pure, Xlib-free decision logic for the X11 backend's window-manager probe.
+ *
+ * The Xlib calls that gather the facts live in x11_core.c; the decisions made
+ * from those facts live here, so they can be unit-tested headlessly with no X
+ * server. Same split, and for the same reason, as x11_geometry.c.
+ *
+ * Nothing in this header names an Xlib type. An X11 Window is an XID, which is
+ * an unsigned long, so the handshake observations below carry it as one. */
+
+#include <stdbool.h>
+
+/* ---------------------------------------------------------------------------
+ * NEOWALL_X11_OVERRIDE_REDIRECT
+ * ------------------------------------------------------------------------- */
+
+/* How the NEOWALL_X11_OVERRIDE_REDIRECT escape hatch was set.
+ *
+ * Only "0" and "1" are accepted. Anything else present in the environment is
+ * X11_OR_ENV_INVALID: the caller warns and falls back to auto-detect, rather
+ * than silently treating a typo ("true", "2", "") as "unset". */
+typedef enum {
+    X11_OR_ENV_UNSET = 0,   /* not in the environment: auto-detect */
+    X11_OR_ENV_FORCE_ON,    /* "1": force override-redirect */
+    X11_OR_ENV_FORCE_OFF,   /* "0": force a managed window */
+    X11_OR_ENV_INVALID,     /* present but unrecognised: warn, then auto-detect */
+} x11_or_env_t;
+
+/* Classify a NEOWALL_X11_OVERRIDE_REDIRECT value. NULL (absent from the
+ * environment) is X11_OR_ENV_UNSET; "" is X11_OR_ENV_INVALID, because the user
+ * clearly meant to set something. */
+x11_or_env_t x11_or_env_parse(const char *value);
+
+/* True if the env var pinned the choice, so auto-detection (and the later
+ * heal-on-WM-appearance) must not override it. */
+bool x11_or_env_is_forced(x11_or_env_t env);
+
+/* ---------------------------------------------------------------------------
+ * _NET_SUPPORTING_WM_CHECK handshake
+ * ------------------------------------------------------------------------- */
+
+/* What the two-step _NET_SUPPORTING_WM_CHECK read actually observed.
+ *
+ * EWMH 1.5: the root property names a window, and that window must carry the
+ * same property naming itself. A window manager that exited without cleaning up
+ * leaves the root property behind, so the root alone proves nothing — only the
+ * self-reference proves a WM is still alive. Reading the property off a window
+ * that no longer exists raises BadWindow, which the caller catches and reports
+ * here as x_error. */
+typedef struct {
+    bool root_prop_valid;      /* root carries the property, type XA_WINDOW, format 32, 1 item */
+    unsigned long root_names;  /* the window the root property names; 0 == None */
+    bool child_prop_valid;     /* that window carries the property, right type/format/count */
+    unsigned long child_names; /* the window the child property names */
+    bool x_error;              /* an X error was raised while reading the child */
+
+    /* _NET_SUPPORTED, read off the root alongside the handshake. */
+    bool supported_prop_valid;   /* root carries _NET_SUPPORTED, type XA_ATOM, format 32 */
+    bool desktop_in_supported;   /* _NET_WM_WINDOW_TYPE_DESKTOP is in that list */
+} x11_wm_check_obs_t;
+
+/* True if the observations prove a live EWMH window manager owns the screen. */
+bool x11_ewmh_wm_check_decide(const x11_wm_check_obs_t *obs);
+
+/* True if a live EWMH window manager owns the screen AND advertises
+ * _NET_WM_WINDOW_TYPE_DESKTOP in _NET_SUPPORTED.
+ *
+ * Liveness alone is the wrong question for choosing a managed window. The
+ * handshake proves an EWMH WM is running; it says nothing about whether that WM
+ * will stack a DESKTOP-typed window below everything. dwm and i3 both pass the
+ * handshake, and neither handles _NET_WM_WINDOW_TYPE_DESKTOP: dwm tiles every
+ * managed window (its only window-type rule is DIALOG -> floating, dwm.c
+ * updatewindowtype), and i3 has no DESKTOP handling in manage.c — worse, our
+ * _NET_WM_DESKTOP = 0xFFFFFFFF makes i3 float the window above the tiling
+ * layer. A managed wallpaper under either is strictly worse than the
+ * override-redirect path this backend has always used for them.
+ *
+ * EWMH 1.5 ("_NET_SUPPORTED... MUST be set by the Window Manager to indicate
+ * which hints it supports") makes the advertisement authoritative, and dwm and
+ * i3 both omit _NET_WM_WINDOW_TYPE_DESKTOP from it while metacity (observed on
+ * Xvfb) and bspwm (bspwm.c net_atoms) include it. A WM that honours DESKTOP
+ * without advertising it stays on the override-redirect path — the
+ * pre-detection behaviour — and NEOWALL_X11_OVERRIDE_REDIRECT=0 forces managed
+ * for exactly that case. */
+bool x11_ewmh_wm_manages_desktop(const x11_wm_check_obs_t *obs);
+
+/* ---------------------------------------------------------------------------
+ * Decisions
+ * ------------------------------------------------------------------------- */
+
+/* Should the wallpaper windows be created override-redirect?
+ *
+ * An override-redirect window is by definition not managed by the window
+ * manager, so no WM ever reads its _NET_WM_WINDOW_TYPE and the DESKTOP hint has
+ * no effect. With an EWMH WM running we want a *managed* window so the WM sees
+ * the hint and stacks it as the desktop. With no WM nothing would stack it for
+ * us, so override-redirect plus the XLowerWindow path is kept. */
+bool x11_or_decide(x11_or_env_t env, bool wm_present);
+
+/* What to do about the wallpaper windows when the window manager comes or goes.
+ *
+ * The wallpaper window is created override-redirect when no WM is running (so
+ * XLowerWindow + the raise-the-other-children loop can stack it) and managed
+ * when one is (so the WM stacks it as the desktop). Both edges have to be acted
+ * on, and in both directions the window must be *recreated*: override_redirect
+ * is fixed at XCreateWindow time.
+ *
+ *  - WM appears (we are override-redirect): recreate managed. A wallpaper daemon
+ *    autostarted at login routinely wins the race against the WM; without this it
+ *    stays override-redirect for the whole session and paints over every window
+ *    the WM later maps.
+ *
+ *  - WM disappears (we are managed): recreate override-redirect. This restores
+ *    exactly the state the daemon would have been in had it started with no WM
+ *    running, which re-arms the XLowerWindow path. It is not optional: observed
+ *    on Xvfb under metacity, and under a deliberately reparenting test WM, the
+ *    wallpaper window's contents are lost when the WM dies and — for a static
+ *    image, where needs_redraw is cleared after the first frame (eventloop.c) —
+ *    are never repainted, leaving the wallpaper permanently black.
+ *
+ *  - env_forced: the user pinned the choice with NEOWALL_X11_OVERRIDE_REDIRECT;
+ *    never override it in either direction.
+ *
+ * Both edges are idempotent: the action depends on the window state we actually
+ * have, so a repeated PropertyNotify for an unchanged situation does nothing.
+ * The caller debounces the WM-disappeared edge (see X11_WM_GONE_DEBOUNCE_MS),
+ * because a WM restart flaps the property down and straight back up. */
+typedef enum {
+    X11_WM_ACTION_NONE = 0,
+    X11_WM_ACTION_RECREATE_MANAGED,   /* WM appeared: override-redirect -> managed */
+    X11_WM_ACTION_RECREATE_OVERRIDE,  /* WM went away: managed -> override-redirect */
+} x11_wm_action_t;
+
+x11_wm_action_t x11_wm_transition(bool env_forced, bool current_override_redirect,
+                                  bool wm_present_now);
+
+/* How long to wait, after _NET_SUPPORTING_WM_CHECK says the WM is gone, before
+ * believing it and recreating on the override-redirect path.
+ *
+ * A WM restart (`metacity --replace` and friends) tears the old WM down and
+ * brings a new one up; if the property is briefly absent or stale in between, an
+ * undebounced down-edge would destroy and recreate every wallpaper window, only
+ * to do it again when the new WM announces itself. Waiting and re-probing turns
+ * that into a no-op, at the cost of the wallpaper being stale for up to this long
+ * after a genuine WM crash. */
+#define X11_WM_GONE_DEBOUNCE_MS 1500
+
+#endif /* NEOWALL_X11_WM_DETECT_H */

--- a/src/eventloop.c
+++ b/src/eventloop.c
@@ -853,6 +853,19 @@ void event_loop_run(struct neowall_state *state) {
             timeout_ms = 0;
         }
 
+        /* Don't sleep on work we already have. A backend can hold events in a
+         * userspace queue that poll() cannot see (Xlib does: any XSync/XFlush
+         * drains the socket into it), in which case the fd looks quiet and we
+         * would block for the whole timeout with events already in hand.
+         *
+         * Measured on Xvfb before this check: when the wallpaper window's contents
+         * were discarded, the Expose saying so reached Xlib's queue at once but was
+         * not dispatched for a further 1.000 s — exactly the timeout above — and a
+         * static wallpaper stayed black for that second. */
+        if (ops && ops->has_pending_events && ops->has_pending_events(backend_data)) {
+            timeout_ms = 0;
+        }
+
         /* Poll for events */
         int ret = poll(fds, num_fds, timeout_ms);
 

--- a/tests/test_x11_wm_detect.c
+++ b/tests/test_x11_wm_detect.c
@@ -1,0 +1,328 @@
+/* Unit tests for the X11 window-manager detection decisions (x11_wm_detect.c).
+ *
+ * Pure decision logic, no Xlib / display server — runs headless in CI. Covers
+ * the two-step _NET_SUPPORTING_WM_CHECK handshake (including the stale-property
+ * case that raises BadWindow), the NEOWALL_X11_OVERRIDE_REDIRECT contract, and
+ * the "a window manager started after we did" heal edge.
+ */
+#include <stdio.h>
+#include <string.h>
+
+#include "x11_wm_detect.h"
+
+static int failures = 0;
+static int checks = 0;
+
+#define CHECK(cond)                                                            \
+    do {                                                                       \
+        checks++;                                                              \
+        if (!(cond)) {                                                         \
+            failures++;                                                        \
+            fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);    \
+        }                                                                      \
+    } while (0)
+
+/* An arbitrary window id standing in for the WM's check window. */
+#define WM_WIN 0x400001UL
+
+/* ---------------------------------------------------------------------------
+ * The two-step _NET_SUPPORTING_WM_CHECK handshake
+ * ------------------------------------------------------------------------- */
+
+static void test_wm_check_decide(void) {
+    /* A live EWMH WM: root names a window, that window names itself. */
+    x11_wm_check_obs_t live = {
+        .root_prop_valid = true,
+        .root_names = WM_WIN,
+        .child_prop_valid = true,
+        .child_names = WM_WIN,
+        .x_error = false,
+    };
+    CHECK(x11_ewmh_wm_check_decide(&live));
+
+    /* Bare X server: no property on the root at all. */
+    x11_wm_check_obs_t bare;
+    memset(&bare, 0, sizeof(bare));
+    CHECK(!x11_ewmh_wm_check_decide(&bare));
+
+    /* Property present but names None. */
+    x11_wm_check_obs_t names_none = live;
+    names_none.root_names = 0;
+    CHECK(!x11_ewmh_wm_check_decide(&names_none));
+
+    /* Root property present but the wrong type/format/count — treated as absent. */
+    x11_wm_check_obs_t bad_type = live;
+    bad_type.root_prop_valid = false;
+    CHECK(!x11_ewmh_wm_check_decide(&bad_type));
+
+    /* STALE: a WM exited without cleaning up. The root still names a window, but
+     * that window is gone, so reading its property raised BadWindow. This is the
+     * case the temporary error handler in x11_core.c exists for; the answer must
+     * be "no live WM", not a crash and not a false positive. */
+    x11_wm_check_obs_t stale = {
+        .root_prop_valid = true,
+        .root_names = WM_WIN,
+        .child_prop_valid = false,
+        .child_names = 0,
+        .x_error = true,
+    };
+    CHECK(!x11_ewmh_wm_check_decide(&stale));
+
+    /* An x_error must lose even if a child property was somehow also read. */
+    x11_wm_check_obs_t stale_but_read = live;
+    stale_but_read.x_error = true;
+    CHECK(!x11_ewmh_wm_check_decide(&stale_but_read));
+
+    /* The window exists and carries the property, but it names someone else —
+     * not a self-reference, so it does not prove a live WM. */
+    x11_wm_check_obs_t not_self = live;
+    not_self.child_names = WM_WIN + 1;
+    CHECK(!x11_ewmh_wm_check_decide(&not_self));
+
+    /* The window exists but has no such property. */
+    x11_wm_check_obs_t no_child_prop = live;
+    no_child_prop.child_prop_valid = false;
+    CHECK(!x11_ewmh_wm_check_decide(&no_child_prop));
+
+    CHECK(!x11_ewmh_wm_check_decide(NULL));
+}
+
+/* ---------------------------------------------------------------------------
+ * Desktop-type support: liveness is not enough for a managed window
+ * ------------------------------------------------------------------------- */
+
+static void test_wm_manages_desktop(void) {
+    /* metacity / bspwm: live, and _NET_SUPPORTED advertises
+     * _NET_WM_WINDOW_TYPE_DESKTOP. Managed is safe. */
+    x11_wm_check_obs_t desktop_wm = {
+        .root_prop_valid = true,
+        .root_names = WM_WIN,
+        .child_prop_valid = true,
+        .child_names = WM_WIN,
+        .x_error = false,
+        .supported_prop_valid = true,
+        .desktop_in_supported = true,
+    };
+    CHECK(x11_ewmh_wm_manages_desktop(&desktop_wm));
+
+    /* dwm / i3: pass the liveness handshake, but _NET_SUPPORTED does not list
+     * _NET_WM_WINDOW_TYPE_DESKTOP. dwm tiles every managed window; i3 floats a
+     * window with _NET_WM_DESKTOP=0xFFFFFFFF above the tiling layer. Handing
+     * either a managed wallpaper is worse than override-redirect, so the answer
+     * must be no even though the WM is alive. */
+    x11_wm_check_obs_t tiling_wm = desktop_wm;
+    tiling_wm.desktop_in_supported = false;
+    CHECK(x11_ewmh_wm_check_decide(&tiling_wm));       /* alive... */
+    CHECK(!x11_ewmh_wm_manages_desktop(&tiling_wm));   /* ...but not desktop-capable */
+
+    /* Live WM with no _NET_SUPPORTED at all (an EWMH violation): conservative
+     * answer, keep the override-redirect path. */
+    x11_wm_check_obs_t no_supported = desktop_wm;
+    no_supported.supported_prop_valid = false;
+    no_supported.desktop_in_supported = false;
+    CHECK(!x11_ewmh_wm_manages_desktop(&no_supported));
+
+    /* A stale _NET_SUPPORTED left by a dead WM must not outvote liveness. */
+    x11_wm_check_obs_t dead_wm = desktop_wm;
+    dead_wm.child_prop_valid = false;
+    dead_wm.x_error = true;
+    CHECK(!x11_ewmh_wm_manages_desktop(&dead_wm));
+
+    CHECK(!x11_ewmh_wm_manages_desktop(NULL));
+}
+
+/* ---------------------------------------------------------------------------
+ * NEOWALL_X11_OVERRIDE_REDIRECT contract
+ * ------------------------------------------------------------------------- */
+
+static void test_env_parse(void) {
+    /* Absent from the environment. */
+    CHECK(x11_or_env_parse(NULL) == X11_OR_ENV_UNSET);
+
+    /* The two documented values. */
+    CHECK(x11_or_env_parse("1") == X11_OR_ENV_FORCE_ON);
+    CHECK(x11_or_env_parse("0") == X11_OR_ENV_FORCE_OFF);
+
+    /* Everything else is a mistake, and must be distinguishable from "unset" so
+     * the caller can warn instead of silently auto-detecting. */
+    CHECK(x11_or_env_parse("") == X11_OR_ENV_INVALID);
+    CHECK(x11_or_env_parse("2") == X11_OR_ENV_INVALID);
+    CHECK(x11_or_env_parse("true") == X11_OR_ENV_INVALID);
+    CHECK(x11_or_env_parse("false") == X11_OR_ENV_INVALID);
+    CHECK(x11_or_env_parse("yes") == X11_OR_ENV_INVALID);
+    CHECK(x11_or_env_parse(" ") == X11_OR_ENV_INVALID);
+    CHECK(x11_or_env_parse(" 1") == X11_OR_ENV_INVALID);
+    CHECK(x11_or_env_parse("1 ") == X11_OR_ENV_INVALID);
+    CHECK(x11_or_env_parse("10") == X11_OR_ENV_INVALID);
+    CHECK(x11_or_env_parse("01") == X11_OR_ENV_INVALID);
+
+    /* Only an explicit 0/1 pins the choice. */
+    CHECK(x11_or_env_is_forced(X11_OR_ENV_FORCE_ON));
+    CHECK(x11_or_env_is_forced(X11_OR_ENV_FORCE_OFF));
+    CHECK(!x11_or_env_is_forced(X11_OR_ENV_UNSET));
+    CHECK(!x11_or_env_is_forced(X11_OR_ENV_INVALID));
+}
+
+static void test_or_decide(void) {
+    /* Auto-detect: a WM means managed, no WM means override-redirect. */
+    CHECK(x11_or_decide(X11_OR_ENV_UNSET, true) == false);
+    CHECK(x11_or_decide(X11_OR_ENV_UNSET, false) == true);
+
+    /* Forced, regardless of what is actually running. */
+    CHECK(x11_or_decide(X11_OR_ENV_FORCE_ON, true) == true);
+    CHECK(x11_or_decide(X11_OR_ENV_FORCE_ON, false) == true);
+    CHECK(x11_or_decide(X11_OR_ENV_FORCE_OFF, true) == false);
+    CHECK(x11_or_decide(X11_OR_ENV_FORCE_OFF, false) == false);
+
+    /* An unrecognised value warns and then behaves exactly as if unset — it must
+     * never be read as one of the two real values. */
+    CHECK(x11_or_decide(X11_OR_ENV_INVALID, true) == x11_or_decide(X11_OR_ENV_UNSET, true));
+    CHECK(x11_or_decide(X11_OR_ENV_INVALID, false) == x11_or_decide(X11_OR_ENV_UNSET, false));
+}
+
+/* ---------------------------------------------------------------------------
+ * The heal edge: a window manager started after we did
+ * ------------------------------------------------------------------------- */
+
+static void test_transition(void) {
+    const bool forced = true, autodetect = false;
+    const bool is_or = true, is_managed = false;
+    const bool wm = true, no_wm = false;
+
+    /* Autostarted at login, raced the WM and lost, so we came up
+     * override-redirect. The WM is up now: recreate as managed, or we paint over
+     * every window for the rest of the session. */
+    CHECK(x11_wm_transition(autodetect, is_or, wm) == X11_WM_ACTION_RECREATE_MANAGED);
+
+    /* Managed, and the WM died. Recreate override-redirect: nothing is left to
+     * stack the window, and (observed on Xvfb) nothing repaints it either — a
+     * static-image wallpaper goes black and stays black, because needs_redraw was
+     * cleared after its first frame. */
+    CHECK(x11_wm_transition(autodetect, is_managed, no_wm) == X11_WM_ACTION_RECREATE_OVERRIDE);
+
+    /* Steady states: the window already matches the world. Both must be no-ops, so
+     * that a repeated PropertyNotify cannot churn windows. */
+    CHECK(x11_wm_transition(autodetect, is_managed, wm) == X11_WM_ACTION_NONE);
+    CHECK(x11_wm_transition(autodetect, is_or, no_wm) == X11_WM_ACTION_NONE);
+
+    /* The user pinned the choice with NEOWALL_X11_OVERRIDE_REDIRECT. Never
+     * second-guess it, in either direction, whatever the WM does. */
+    CHECK(x11_wm_transition(forced, is_or, wm) == X11_WM_ACTION_NONE);
+    CHECK(x11_wm_transition(forced, is_or, no_wm) == X11_WM_ACTION_NONE);
+    CHECK(x11_wm_transition(forced, is_managed, wm) == X11_WM_ACTION_NONE);
+    CHECK(x11_wm_transition(forced, is_managed, no_wm) == X11_WM_ACTION_NONE);
+}
+
+/* The whole late-WM sequence, as the daemon actually walks it: probe at init,
+ * then re-probe on each root PropertyNotify. */
+static void test_late_wm_sequence(void) {
+    x11_or_env_t env = x11_or_env_parse(NULL);  /* nothing forced */
+    bool forced = x11_or_env_is_forced(env);
+
+    /* Init, no WM yet: the root property is absent. */
+    x11_wm_check_obs_t obs;
+    memset(&obs, 0, sizeof(obs));
+    bool wm_present = x11_ewmh_wm_manages_desktop(&obs);
+    bool override_redirect = x11_or_decide(env, wm_present);
+    CHECK(!wm_present);
+    CHECK(override_redirect);  /* came up override-redirect */
+
+    /* metacity starts and publishes the handshake and its _NET_SUPPORTED.
+     * PropertyNotify -> re-probe. */
+    x11_wm_check_obs_t up = {
+        .root_prop_valid = true,
+        .root_names = WM_WIN,
+        .child_prop_valid = true,
+        .child_names = WM_WIN,
+        .x_error = false,
+        .supported_prop_valid = true,
+        .desktop_in_supported = true,
+    };
+    wm_present = x11_ewmh_wm_manages_desktop(&up);
+    CHECK(wm_present);
+
+    /* A starting WM's write order between _NET_SUPPORTING_WM_CHECK and
+     * _NET_SUPPORTED is not specified. If the handshake lands first, this probe
+     * says "not yet" — and the _NET_SUPPORTED PropertyNotify that follows
+     * triggers the re-probe that heals it (x11_dispatch_events watches both). */
+    x11_wm_check_obs_t handshake_first = up;
+    handshake_first.supported_prop_valid = false;
+    handshake_first.desktop_in_supported = false;
+    CHECK(!x11_ewmh_wm_manages_desktop(&handshake_first));
+    CHECK(x11_wm_transition(forced, override_redirect, false) == X11_WM_ACTION_NONE);
+    CHECK(x11_wm_transition(forced, override_redirect, wm_present) ==
+          X11_WM_ACTION_RECREATE_MANAGED);
+    override_redirect = false;  /* recreated managed */
+
+    /* A second PropertyNotify for the same WM must not recreate anything again. */
+    CHECK(x11_wm_transition(forced, override_redirect, wm_present) == X11_WM_ACTION_NONE);
+
+    /* The WM is killed, leaving the property stale (BadWindow on the check
+     * window). Nothing is left to stack or repaint the wallpaper, so go back to
+     * the override-redirect setup we would have had if we had started with no WM. */
+    x11_wm_check_obs_t gone = {
+        .root_prop_valid = true,
+        .root_names = WM_WIN,
+        .child_prop_valid = false,
+        .child_names = 0,
+        .x_error = true,
+        .supported_prop_valid = true,   /* stale, like the handshake property */
+        .desktop_in_supported = true,
+    };
+    wm_present = x11_ewmh_wm_manages_desktop(&gone);
+    CHECK(!wm_present);
+    CHECK(x11_wm_transition(forced, override_redirect, wm_present) ==
+          X11_WM_ACTION_RECREATE_OVERRIDE);
+    override_redirect = true;  /* recreated override-redirect */
+
+    /* And that is a steady state again. */
+    CHECK(x11_wm_transition(forced, override_redirect, wm_present) == X11_WM_ACTION_NONE);
+}
+
+/* A WM restart (`--replace`). The property flaps down and straight back up. The
+ * daemon debounces the down-edge (X11_WM_GONE_DEBOUNCE_MS) and re-probes when it
+ * expires, so the whole restart must cost ZERO window rebuilds. */
+static void test_wm_replace_is_a_noop(void) {
+    bool forced = false;
+    bool override_redirect = false;  /* running managed under the old WM */
+
+    x11_wm_check_obs_t old_wm = {
+        .root_prop_valid = true, .root_names = WM_WIN,
+        .child_prop_valid = true, .child_names = WM_WIN,
+        .supported_prop_valid = true, .desktop_in_supported = true,
+    };
+    x11_wm_check_obs_t none;
+    memset(&none, 0, sizeof(none));
+    x11_wm_check_obs_t new_wm = old_wm;
+    new_wm.root_names = WM_WIN + 9;
+    new_wm.child_names = WM_WIN + 9;
+
+    CHECK(x11_ewmh_wm_manages_desktop(&old_wm));
+
+    /* Down-edge: the old WM is gone. The action is real now, which is exactly why
+     * it must be deferred rather than applied here. */
+    CHECK(!x11_ewmh_wm_manages_desktop(&none));
+    CHECK(x11_wm_transition(forced, override_redirect, false) ==
+          X11_WM_ACTION_RECREATE_OVERRIDE);
+    /* ...so the caller arms the deadline instead of rebuilding. */
+
+    /* The replacement WM announces itself before the deadline expires. The caller
+     * cancels the pending rebuild, and the transition from the state we are
+     * ACTUALLY in (still managed) with a WM present is a no-op. */
+    CHECK(x11_ewmh_wm_manages_desktop(&new_wm));
+    CHECK(x11_wm_transition(forced, override_redirect, true) == X11_WM_ACTION_NONE);
+    CHECK(!override_redirect);  /* never rebuilt, never flickered */
+}
+
+int main(void) {
+    test_wm_check_decide();
+    test_wm_manages_desktop();
+    test_env_parse();
+    test_or_decide();
+    test_transition();
+    test_late_wm_sequence();
+    test_wm_replace_is_a_noop();
+
+    printf("x11_wm_detect: %d checks, %d failures\n", checks, failures);
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
On an EWMH desktop the wallpaper currently renders **above every window**. On Linux Mint 22.3 / Cinnamon (Muffin), starting neowall covers the whole desktop. Reproduced at `9e9f285` under metacity too: the app-window pixel reads the wallpaper's colour.

#52 (`d51ab08`) set `_NET_WM_WINDOW_TYPE_DESKTOP` and the `_NET_WM_STATE` atoms, but `x11_create_surface()` still hardcodes `attrs.override_redirect = True`. An override-redirect window is not managed, so no WM reads those properties. The hints are correct and inert, which is what #52 says of itself: "a conformance fix rather than an observable behaviour change". Stacking is left to `XLowerWindow()` plus a raise-loop, and under Muffin that loses.

## Managed only when the WM actually supports desktop windows

The window is created WM-managed **only if the WM advertises `_NET_WM_WINDOW_TYPE_DESKTOP` in `_NET_SUPPORTED`**, not merely if a WM is alive.

This distinction matters for this backend specifically, which targets tiling WMs. **dwm and i3 pass the `_NET_SUPPORTING_WM_CHECK` liveness handshake but do not support desktop windows** — i3 floats a window carrying `_NET_WM_DESKTOP = 0xFFFFFFFF` above the tiling layer, and dwm's only window-type rule is DIALOG→floating, so it would tile the wallpaper. Neither lists DESKTOP in `_NET_SUPPORTED`; metacity and bspwm do. A liveness-only gate would have regressed exactly the window managers this backend is named for. All four were run; the matrix is below.

## Tracking the WM for the life of the session

A wallpaper daemon autostarts at login, so racing the WM is its normal condition. Probing once and caching meant losing that race latched override-redirect forever.

Watched: `PropertyNotify` on `_NET_SUPPORTING_WM_CHECK` **and on `_NET_SUPPORTED`** (a WM may set the handshake before it publishes its supported atoms), plus `DestroyNotify` on the check window. That last one is load-bearing: a SIGKILLed WM leaves its root property **unchanged**, and X signals `PropertyNotify` only on a *change*, so a hard-killed WM fires **zero** PropertyNotify events. Observed. WM death is debounced 1500 ms so a `--replace` restart causes no rebuild.

## Three bugs this change would otherwise have introduced

**Black wallpaper for exactly 1.000 s after any rebuild.** Xlib queues events in userspace, so a 1000 ms `poll()` timeout on a now-quiet fd left the `Expose` unread for a full second. A `has_pending_events()` backend op fixes it (X11 answers `XPending()`; Wayland is unaffected). Measured 0.00% idle CPU after the change, and under a 3M-event storm.

**A crash.** `x11_occlusion.c` walks `_NET_CLIENT_LIST_STACKING`. A SIGKILLed WM leaves it stale, naming the managed wallpaper window this PR then destroys → `BadWindow` → Xlib's default handler **exits the process**. An override-redirect window never enters that list, so this is new with managed windows. Fixed with a scoped handler that tolerates only `BadWindow`/`BadDrawable` and logs anything else.

**A dangling root-pixmap XID.** Destroying a surface freed its `root_pixmap` while `_XROOTPMAP_ID`/`ESETROOT_PMAP_ID` still advertised it, so pseudo-transparency clients got a freed XID (6 `BadDrawable` observations across a double rebuild, sampled at 2 ms). Shutdown never called the destroy path at all, leaving a dead XID published permanently. The advertisement is now withdrawn before the free, and on exit.

Also: X windows do not retain contents, and a static image is drawn once with `needs_redraw` then cleared, so any restack left it permanently black. A shader redraws every frame and hides this entirely.

## Properties a managed window owes

ICCCM 4.1.2.5 requires `WM_CLASS` when a window leaves the Withdrawn state; override-redirect windows are exempt, so this PR *creates* the obligation. Nothing in `src/` set `WM_CLASS` or `WM_NAME` — while the X11 backend README documented both as set. Now the code sets them and the README describes the code. Also `_NET_WM_DESKTOP = 0xFFFFFFFF` (STICKY is viewport-fixed, not all-desktops) and `WM_NORMAL_HINTS` with `PPosition|PSize`.

## Verification

Xvfb + metacity, **static image** wallpaper (a shader hides repaint bugs), sampling **on-screen root pixels** with a calibration control:

| scenario | app pixel | wallpaper pixel |
|---|---|---|
| no WM / WM at start / WM late / `kill -9` / `--replace` / double rebuild | `#00FF00` | `#FF0000` |

`--replace`: zero rebuilds. Idle CPU 0.00%. `meson test` 12/12 from a clean `git archive` build; `x11_wm_detect` is a pure seam (no Xlib types in its signature, following the `x11_geometry.c` precedent) with 64 headless checks. No display-dependent test added to `meson.build`.

On Muffin (dual 2560×1440): gate resolves to managed, and `xwininfo`/`xprop` on the wallpaper window report `Override Redirect State: no`, `WM_CLASS = "neowall", "NeoWall"`, `_NET_WM_WINDOW_TYPE_DESKTOP`, `_NET_WM_DESKTOP = 4294967295`, wallpaper behind the windows.

### Against the window managers this backend actually targets

The capability gate was written from reading i3/dwm/bspwm sources. It has since been verified by running them (Xvfb, static image, root-pixel sampling):

| WM | `_NET_SUPPORTED` advertises DESKTOP | gate chose | Override Redirect | wallpaper below app |
|---|---|---|---|---|
| metacity (control) | yes | managed | no | yes |
| **i3** 4.23 | **no** | **override-redirect** | yes | yes |
| **dwm** 6.4 | **no** (9 atoms; only DIALOG) | **override-redirect** | yes | yes |
| **bspwm** 0.9.10 | yes | managed | no | yes |

bspwm's DESKTOP support is functional, not merely advertised: the app filled its tile alone rather than splitting it with the wallpaper. Without the gate, i3 and dwm would both have gone managed.

### Resource churn

50 complete WM up/down cycles against one long-lived daemon, each rebuild confirmed in the log (both directions):

| cycle | RSS (KB) | FDs | X windows |
|---|---|---|---|
| 0 | 121376 | 9 | 4 |
| 10 | 121300 | 9 | 4 |
| 20 | 121300 | 9 | 4 |
| 30 | 121300 | 9 | 4 |
| 40 | 121300 | 9 | 4 |
| 50 | 121300 | 9 | 4 |

Flat. CPU linear at ~4.7 ticks/cycle (work, not spin). Wallpaper still renders correctly, below an ordinary app window, after 50 cycles.

### Multi-monitor

On dual 2560×1440 (X11, Muffin), both wallpaper windows are created and both are managed:

```
0x9800003  2560x1440+2560+0  override_redirect=no   DisplayPort-0
0x9800006  2560x1440+0+0     override_redirect=no   DisplayPort-1
```

`x11_recreate_surfaces()` snapshots every output under the list lock and rebuilds each, so a heal covers both. That part is a code read: **the heal itself has not been run on dual-head**, because triggering it means killing the session's window manager.

Behaviour under window managers other than metacity, Muffin, i3, dwm and bspwm is untested here. The override-redirect path's stacking is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
