### PR TITLE
feat: span one shader across every monitor in a group

### DIFF
--- a/include/neowall/output/output.h
+++ b/include/neowall/output/output.h
@@ -9,6 +9,7 @@
 #include "neowall/result.h"        /* For nw_result */
 #include "neowall/image/image.h"   /* For struct image_data and enum image_format */
 #include "neowall/shader/shader_multipass.h"  /* For multipass_shader_t */
+#include "neowall/output/span.h"   /* For struct span_view */
 
 /* Constants */
 #define OUTPUT_MAX_PATH_LENGTH 4096
@@ -91,13 +92,38 @@ struct output_state {
     int32_t scale;
     int32_t transform;
 
-    /* Position of this output's top-left within the global screen layout, in
-     * pixels. Zero for single-output / per-output compositors (Wayland binds a
-     * surface per wl_output, so the origin is always 0,0). Set by the X11
-     * backend from the RandR monitor geometry so the wallpaper window lands on
-     * the right monitor and pointer coordinates can be made output-relative. */
+    /* Position of this output's top-left within the global screen layout.
+     * Set by the X11 backend from the RandR monitor geometry (device pixels) so
+     * the wallpaper window lands on the right monitor and pointer coordinates
+     * can be made output-relative, and by the Wayland backend from xdg-output's
+     * logical position, which is in LOGICAL pixels and so agrees with the fields
+     * above only where scale is 1. Also the origin of this output's slice of a
+     * spanned wallpaper (see span.h). */
     int32_t x_offset;
     int32_t y_offset;
+
+    /* This output's slice of the wallpaper it shares with its span group: the
+     * outputs whose config names the same wallpaper (or the same cycle list).
+     * The group renders ONE continuous scene rather than a copy each, so the
+     * shader is handed the group's bounding box as iResolution and this slice's
+     * origin as a gl_FragCoord offset. Refreshed each main-loop pass from the
+     * output snapshot (outputs_update_spans); read by the render path.
+     *
+     * `spanned` is false whenever the group is just this output, in which case
+     * `span` is not read at all and rendering is exactly as it was. */
+    struct span_view span;
+    bool spanned;
+
+    /* shader_start_time shared by the whole span group, so both halves of a
+     * spanned scene animate on the same clock. 0 until the group has a shader. */
+    uint64_t span_start_time;
+
+    /* Last shader this output adopted to match its span group. Slicing a scene
+     * across monitors is meaningless unless they run the SAME shader, and the
+     * per-output cycle indices can start out disagreeing (a restored index, a
+     * hotplug mid-cycle). Recording the path we last converged on stops a
+     * shader that fails to compile here from being retried every frame. */
+    char span_synced_path[OUTPUT_MAX_PATH_LENGTH];
 
     char make[64];
     char model[64];
@@ -214,6 +240,17 @@ struct output_state {
     struct output_state *next;
 };
 
+/* Device pixels per logical pixel, never zero. An output carries scale 0 until
+ * the compositor has told it otherwise, and X11 outputs carry 1 forever; both
+ * mean device == logical. Divide a physical width by this to get the logical
+ * width the compositor lays the output out with, multiply to go back. */
+static inline int32_t output_normalized_scale(const struct output_state *output) {
+    if (!output || output->scale <= 0) {
+        return 1;
+    }
+    return output->scale;
+}
+
 /* Output management */
 struct output_state *output_create(struct neowall_state *state,
                                    void *native_output, uint32_t name);
@@ -248,6 +285,30 @@ void output_cycle_wallpaper(struct output_state *output);
 void output_set_cycle_index(struct output_state *output, size_t index);
 bool output_should_cycle(struct output_state *output, uint64_t current_time);
 void output_preload_next_wallpaper(struct output_state *output);
+
+/* True if `a` and `b` draw the same wallpaper and so form one spanned scene:
+ * same type, and either the same cycle list or, when not cycling, the same
+ * source path. Membership deliberately ignores where in the cycle each output
+ * currently is — two outputs on one directory belong together even if a
+ * restored index left them showing different entries; outputs_sync_span_group()
+ * is what brings them back together. */
+bool output_same_span_group(const struct output_state *a, const struct output_state *b);
+
+/* Recompute every output's slice of its span group from the current layout.
+ * Call from the main loop with the output snapshot; sets output->span,
+ * output->spanned and output->span_start_time. */
+void outputs_update_spans(struct output_state **outs, size_t count);
+
+/* Bring `output` onto the same shader as the rest of its span group, if it has
+ * drifted. No-op for an output that is alone in its group or already in step. */
+void outputs_sync_span_group(struct output_state **outs, size_t count, size_t index);
+
+/* Advance `leader` to the next wallpaper and take its whole span group with it,
+ * so a spanned scene never ends up half one shader and half another. Members are
+ * pushed the leader's resulting wallpaper rather than cycling themselves, which
+ * would re-shuffle and re-skip broken entries independently and drift apart.
+ * Returns how many outputs were cycled, the leader included. */
+size_t output_cycle_group(struct output_state **outs, size_t count, struct output_state *leader);
 
 /* Rendering wrappers - hide render module from eventloop */
 bool output_render_frame(struct output_state *output);

--- a/include/neowall/output/span.h
+++ b/include/neowall/output/span.h
@@ -1,0 +1,85 @@
+/* Virtual-screen geometry for spanning one shader across several outputs.
+ *
+ * Split out of the render path (as src/output/cycle_select.c was split out of
+ * output.c) so the bounding-box arithmetic and the Y-axis flip below can be
+ * unit-tested without EGL, GL, or a compositor. Nothing here touches the GPU.
+ */
+#ifndef NEOWALL_OUTPUT_SPAN_H
+#define NEOWALL_OUTPUT_SPAN_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* One output's placement in the screen layout, top-left origin, LOGICAL pixels.
+ *
+ * Two coordinate spaces meet in this file and they are not interchangeable:
+ *
+ *   LOGICAL  the compositor's global layout space, the one every output's
+ *            position is quoted in. A scale-2 monitor is HALF as wide here as
+ *            it is in its own framebuffer. Only this space is shared, so it is
+ *            the only space a bounding box over several outputs means anything
+ *            in. All four fields below are logical.
+ *   DEVICE   one output's own framebuffer, where gl_FragCoord lives. Private to
+ *            that output, and scaled by `scale` from logical. struct span_view
+ *            is entirely device pixels.
+ *
+ * Mixing them silently is what this naming is here to prevent: with a logical
+ * origin and a device extent, a scale-2 monitor's rect SWALLOWS its neighbour's
+ * instead of abutting it, the box collapses onto the one output, and the others
+ * are left rendering slices of a scene nobody is drawing. Nothing downstream can
+ * catch that — the resulting rects are a shape a real layout can also have (a
+ * cloned pair of unequal size nests exactly the same way), so the names and the
+ * caller's derivation are the only guard there is. The caller is the seam: see
+ * outputs_update_spans() in src/output/output.c, which divides the physical
+ * output size by the same scale it passes here.
+ */
+struct span_rect {
+    int32_t logical_x;
+    int32_t logical_y;
+    int32_t logical_w;
+    int32_t logical_h;
+    /* Device pixels per logical pixel on THIS output (wl_output scale; 1 on
+     * X11). Non-positive is read as 1, which is what an output that has not
+     * heard a scale event yet carries. */
+    int32_t scale;
+};
+
+/* What one output must feed its shader to draw its slice of the virtual scene.
+ * DEVICE pixels, at this output's own scale: gl_FragCoord and iResolution are
+ * both framebuffer quantities, so a scale-2 output is handed a virtual screen
+ * twice the size of the one its scale-1 neighbour is handed. Same scene, same
+ * logical extent, sampled at each output's own density. */
+struct span_view {
+    int32_t virt_w;     /* iResolution.x: bounding box of every rect, at my scale */
+    int32_t virt_h;     /* iResolution.y */
+    int32_t off_x;      /* added to gl_FragCoord.x */
+    int32_t off_y;      /* added to gl_FragCoord.y */
+};
+
+/* Virtual view for rects[index] within the bounding box of all `count` rects.
+ *
+ * The box is computed in LOGICAL pixels and the answer is returned in
+ * rects[index]'s OWN device pixels: with mixed scales there is no single device
+ * space to share, so every output is given the same logical scene at its own
+ * density.
+ *
+ * Rects with a non-positive width or height are ignored: an output that has not
+ * been configured yet carries no size, and letting it into the box would drag
+ * the origin to (0,0) and shift every other output's slice.
+ *
+ * off_x is the plain horizontal distance from the box's left edge, but off_y is
+ * NOT the matching vertical distance: gl_FragCoord's origin is the BOTTOM-left
+ * of the window, while span_rect's y grows downward from the TOP of the box. So
+ * the offset that lands this window's bottom row at the right height in the
+ * virtual scene is measured from the box's BOTTOM edge, i.e. the box height less
+ * the rect's bottom edge. Get this backwards and a horizontal layout still looks
+ * right (every off_y is 0) while a stacked one renders the halves swapped.
+ *
+ * Returns false (leaving *out untouched) if index is out of range, if rects[index]
+ * is itself degenerate, or if no rect is valid.
+ */
+bool span_compute(const struct span_rect *rects, size_t count, size_t index,
+                  struct span_view *out);
+
+#endif /* NEOWALL_OUTPUT_SPAN_H */

--- a/include/neowall/shader/shader_multipass.h
+++ b/include/neowall/shader/shader_multipass.h
@@ -106,6 +106,7 @@ typedef struct {
     GLint iFrameRate;
     GLint iFrame;
     GLint iResolution;
+    GLint iSpanOffset;
     GLint iMouse;
     GLint iDate;
     GLint iSampleRate;
@@ -156,6 +157,15 @@ typedef struct {
     bool has_buffers;                        /* True if any buffer passes exist */
     int frame_count;                         /* Frame counter for iFrame uniform */
     double start_time;                       /* Start time for iTime uniform */
+
+    /* Multi-monitor spanning: this context draws one slice of a scene whose
+     * full extent is span_width x span_height. Zero when the output is alone in
+     * its span group, which restores the unspanned sizing and uniforms exactly.
+     * See multipass_set_span(). */
+    int span_width;
+    int span_height;
+    int span_off_x;
+    int span_off_y;
     
     /* Shared resources */
     GLuint vao;                              /* Vertex array object */
@@ -325,6 +335,32 @@ bool multipass_compile_all(multipass_shader_t *shader);
  * @param height New height
  */
 void multipass_resize(multipass_shader_t *shader, int width, int height);
+
+/**
+ * Place this output's window inside a larger virtual screen, so the shader draws
+ * one slice of a scene continuous across every monitor rather than a whole copy
+ * of it. The Image pass reports iResolution as the virtual size and shifts
+ * gl_FragCoord by (off_x, off_y); off_y is measured from the virtual screen's
+ * BOTTOM, since gl_FragCoord's origin is the bottom-left (see span.h).
+ *
+ * Buffer passes are sized to the virtual screen instead of the window: a
+ * Shadertoy buffer is read back as texture(iChannelN, fragCoord/iResolution.xy),
+ * and with a spanned fragCoord those coordinates only address the right texel if
+ * the buffer covers the whole virtual screen. That costs each output the full
+ * virtual-screen buffer work; the Image pass still only fills its own window.
+ *
+ * Pass zeros to clear spanning, which restores the original sizing and uniforms
+ * exactly. Callers do this when the output is alone in its span group, rather
+ * than passing the window's own size, so the lone-output path stays untouched.
+ *
+ * @param shader Multipass shader
+ * @param virt_width Virtual screen width, or 0 for no spanning
+ * @param virt_height Virtual screen height, or 0 for no spanning
+ * @param off_x This window's left edge within the virtual screen
+ * @param off_y This window's bottom edge above the virtual screen's bottom
+ */
+void multipass_set_span(multipass_shader_t *shader, int virt_width, int virt_height,
+                        int off_x, int off_y);
 
 /**
  * Destroy multipass shader and free all resources

--- a/meson.build
+++ b/meson.build
@@ -239,6 +239,7 @@ texture_sources = files(
 # Output sources
 output_sources = files(
   'src/output/output.c',
+  'src/output/span.c',
 )
 
 # Config sources
@@ -547,6 +548,16 @@ test_shuffle_exe = executable('test_shuffle',
 )
 
 test('shuffle', test_shuffle_exe)
+
+# Virtual-screen geometry: the bounding box a spanned shader draws into and the
+# per-output gl_FragCoord offset (whose Y half is flipped). Pure integer math.
+test_span_exe = executable('test_span',
+  files('tests/test_span.c', 'src/output/span.c'),
+  include_directories: [inc_dirs, inc_dirs_build],
+  build_by_default: false,
+)
+
+test('span', test_span_exe)
 
 # =============================================================================
 # Fuzzers (opt-in: -Dfuzz=true, clang only)

--- a/src/compositor/backends/wayland/wayland_core.c
+++ b/src/compositor/backends/wayland/wayland_core.c
@@ -45,10 +45,18 @@ static bool wait_for_outputs_configured(struct neowall_state *state);
 static void xdg_output_handle_logical_position(void *data,
                                                  struct zxdg_output_v1 *xdg_output,
                                                  int32_t x, int32_t y) {
-    (void)data;
+    struct output_state *output = data;
     (void)xdg_output;
-    (void)x;
-    (void)y;
+
+    /* Where this output sits in the layout. A layer-shell surface is bound to a
+     * single wl_output and so always draws at its own origin, but the position
+     * is what tells the shader which slice of a spanned scene this output is
+     * (see span.h). It is a LOGICAL position: it matches the pixel geometry the
+     * span box is built from only where the output's scale is 1. */
+    if (output) {
+        output->x_offset = x;
+        output->y_offset = y;
+    }
 }
 
 static void xdg_output_handle_logical_size(void *data,
@@ -190,12 +198,9 @@ static inline const char *output_readable_name(const struct output_state *output
            (output->model[0] ? output->model : "unknown");
 }
 
-static inline int32_t output_normalized_scale(const struct output_state *output) {
-    if (!output || output->scale <= 0) {
-        return 1;
-    }
-    return output->scale;
-}
+/* output_normalized_scale() lives in neowall/output/output.h: the span code
+ * needs the same normalisation to turn a physical size back into the logical
+ * one the compositor lays out with. */
 
 static bool output_apply_render_size(struct output_state *output,
                                      const char *reason,

--- a/src/eventloop.c
+++ b/src/eventloop.c
@@ -207,8 +207,17 @@ static void render_outputs(struct neowall_state *state) {
     struct swap_vec swaps;
     swap_vec_init(&swaps);
 
+    /* Refresh each output's slice of the scene it shares with its span group.
+     * Cheap, and the layout can change under us at any time (hotplug, RandR). */
+    outputs_update_spans(outputs_snapshot, output_n);
+
     for (size_t idx = 0; idx < output_n; idx++) {
         struct output_state *output = outputs_snapshot[idx];
+
+        /* A spanned scene only reads as one scene if every monitor is drawing
+         * the SAME shader. Outputs can start out disagreeing — a restored cycle
+         * index, a hotplug part-way through a cycle — so converge them here. */
+        outputs_sync_span_group(outputs_snapshot, output_n, idx);
 
         /* Handle set-index request - set ALL outputs with same config to the specified index */
         if (set_index >= 0 && !processed_set_index && output->config->cycle && output->config->cycle_count > 0) {
@@ -246,28 +255,10 @@ static void render_outputs(struct neowall_state *state) {
 
         /* Handle next wallpaper request - cycle ALL outputs with same config for synchronization */
         if (next_count > 0 && !processed_next && output->config->cycle && output->config->cycle_count > 0) {
-            int cycled_count = 0;
-            for (size_t j = idx; j < output_n; j++) {
-                struct output_state *sync_output = outputs_snapshot[j];
-                bool same_config = (sync_output->config->cycle &&
-                                   sync_output->config->cycle_count == output->config->cycle_count);
-                if (same_config && sync_output->config->cycle_paths && output->config->cycle_paths) {
-                    for (size_t i = 0; i < output->config->cycle_count && same_config; i++) {
-                        if (strcmp(sync_output->config->cycle_paths[i], output->config->cycle_paths[i]) != 0) {
-                            same_config = false;
-                        }
-                    }
-                }
-                if (same_config) {
-                    log_debug("Cycling to next wallpaper for output %s (synchronized)",
-                             sync_output->model[0] ? sync_output->model : "unknown");
-                    output_cycle_wallpaper(sync_output);
-                    cycled_count++;
-                }
-            }
+            size_t cycled_count = output_cycle_group(outputs_snapshot, output_n, output);
             current_time = get_time_ms();
             processed_next = true;
-            log_info("Cycled %d output(s) with matching configuration (%d requests remaining)",
+            log_info("Cycled %zu output(s) with matching configuration (%d requests remaining)",
                      cycled_count, next_count - 1);
             atomic_fetch_sub_explicit(&state->next_requested, 1, memory_order_acq_rel);
         }
@@ -276,7 +267,10 @@ static void render_outputs(struct neowall_state *state) {
         if (!atomic_load_explicit(&state->paused, memory_order_acquire) &&
             output->config->cycle && output->config->duration > 0.0f) {
             if (output_should_cycle(output, current_time)) {
-                output_cycle_wallpaper(output);
+                /* Take the whole span group across together: half a scene
+                 * advancing to the next shader on its own is worse than either
+                 * shader on its own. */
+                output_cycle_group(outputs_snapshot, output_n, output);
                 current_time = get_time_ms();
             }
         }

--- a/src/output/output.c
+++ b/src/output/output.c
@@ -1015,6 +1015,285 @@ nw_result output_set_shader(struct output_state *output, const char *shader_path
     return nw_ok();
 }
 
+/* ============================================
+ * Span groups — one scene across several monitors
+ * ============================================ */
+
+/* The wallpaper an output is showing right now, "" if none. */
+static const char *output_live_path(const struct output_state *o) {
+    if (o->config->type == WALLPAPER_SHADER) {
+        return o->config->shader_path;
+    }
+    return o->config->path;
+}
+
+/* Order-independent fingerprint of a cycle list.
+ *
+ * Two outputs pointed at the same directory hold equal lists, but not
+ * necessarily in equal ORDER: shuffle randomises each output's copy separately
+ * when it is loaded. Comparing slot by slot would therefore split a shuffled
+ * pair into two groups of one and quietly disable spanning, so the entries are
+ * summed rather than sequenced — the sum is unchanged by any permutation. */
+static uint64_t cycle_list_digest(const struct wallpaper_config *c) {
+    uint64_t total = 0;
+    for (size_t i = 0; i < c->cycle_count; i++) {
+        const char *p = c->cycle_paths[i];
+        uint64_t h = 1469598103934665603ull;  /* FNV-1a 64 */
+        for (; p && *p; p++) {
+            h ^= (unsigned char)*p;
+            h *= 1099511628211ull;
+        }
+        total += h;
+    }
+    return total;
+}
+
+bool output_same_span_group(const struct output_state *a, const struct output_state *b) {
+    if (!a || !b || !a->config || !b->config) {
+        return false;
+    }
+    const struct wallpaper_config *ca = a->config;
+    const struct wallpaper_config *cb = b->config;
+
+    if (ca->type != cb->type || ca->cycle != cb->cycle) {
+        return false;
+    }
+    if (ca->cycle) {
+        if (ca->cycle_count != cb->cycle_count || !ca->cycle_paths || !cb->cycle_paths) {
+            return false;
+        }
+        return cycle_list_digest(ca) == cycle_list_digest(cb);
+    }
+    return strcmp(output_live_path(a), output_live_path(b)) == 0;
+}
+
+void outputs_update_spans(struct output_state **outs, size_t count) {
+    if (!outs || count == 0) {
+        return;
+    }
+
+    for (size_t i = 0; i < count; i++) {
+        struct output_state *me = outs[i];
+        if (!me) {
+            continue;
+        }
+
+        struct span_rect rects[MAX_OUTPUTS];
+        size_t n = 0;
+        size_t self = 0;
+        uint64_t start = 0;
+
+        for (size_t j = 0; j < count && n < MAX_OUTPUTS; j++) {
+            struct output_state *o = outs[j];
+            if (!o || !output_same_span_group(me, o)) {
+                continue;
+            }
+            if (o == me) {
+                self = n;
+            }
+
+            /* THE UNIT SEAM. x_offset/y_offset are LOGICAL on Wayland (they come
+             * from xdg-output's logical_position) while width/height are the
+             * PHYSICAL framebuffer (logical * scale). span_rect wants all four
+             * logical, so divide the size by the same scale — exact, because the
+             * Wayland backend produced width as logical*scale in the first place.
+             * On X11 scale is 1 and every quantity here is already device pixels,
+             * so this is arithmetically the identity. */
+            int32_t scale = output_normalized_scale(o);
+            rects[n++] = (struct span_rect){
+                .logical_x = o->x_offset,
+                .logical_y = o->y_offset,
+                .logical_w = o->width / scale,
+                .logical_h = o->height / scale,
+                .scale     = scale,
+            };
+
+            /* Earliest start in the group, so every member's iTime agrees. A
+             * member that loaded a moment later must not run a moment behind:
+             * the seam between two halves of one scene shows any phase gap. */
+            if (o->shader_start_time > 0 && (start == 0 || o->shader_start_time < start)) {
+                start = o->shader_start_time;
+            }
+        }
+
+        me->span_start_time = start;
+
+        struct span_view v;
+        if (n < 2 || !span_compute(rects, n, self, &v)) {
+            me->spanned = false;
+            continue;
+        }
+        /* Degenerate group: the box came out exactly this output's own size at
+         * zero offset, which means every peer's rect lies inside this one's. The
+         * spanned path would hand the shader this output's own resolution and no
+         * offset — precisely what the standalone path already does — so short-
+         * circuit it. Reached by a cloned/mirrored group (several outputs on one
+         * logical region, equal or nested, as `xrandr --same-as` produces), where
+         * each peer is separately either degenerate itself or given the sub-rect
+         * of the box it actually covers.
+         *
+         * It is ALSO how a group whose rects were built from mismatched units
+         * presents, because a swallowed neighbour nests exactly like a smaller
+         * clone. The two are indistinguishable from the rects alone, so this is
+         * logged rather than rejected: a wrongly-nested group is a bug at the
+         * seam above, not something to detect down here. */
+        if (v.virt_w == me->width && v.virt_h == me->height &&
+            v.off_x == 0 && v.off_y == 0) {
+            if (me->spanned) {
+                log_debug("Output %s: no longer spanning, its logical rect "
+                          "%dx%d+%d+%d (scale %d) contains every peer's in the group",
+                          output_get_identifier(me),
+                          rects[self].logical_w, rects[self].logical_h,
+                          rects[self].logical_x, rects[self].logical_y, rects[self].scale);
+            }
+            me->spanned = false;
+            continue;
+        }
+        if (!me->spanned) {
+            log_debug("Output %s: spanning, drawing %dx%d+%d+%d of a %dx%d virtual screen",
+                      output_get_identifier(me),
+                      me->width, me->height, v.off_x, v.off_y, v.virt_w, v.virt_h);
+        }
+        me->span = v;
+        me->spanned = true;
+    }
+}
+
+/* Slot of `path` in a `count`-long cycle list, or `fallback` if it is absent.
+ *
+ * A shuffled cycle pass permutes the list in place when it wraps, so an index
+ * captured before a pass no longer names the same entry after it. The entry that
+ * is actually live is known by path, so its slot is re-found by string compare
+ * rather than carried as an index. */
+static size_t cycle_restore_index(char *const *paths, size_t count, const char *path,
+                                  size_t fallback) {
+    if (!paths || !path || path[0] == '\0') return fallback;
+
+    for (size_t i = 0; i < count; i++) {
+        if (paths[i] && strcmp(paths[i], path) == 0) return i;
+    }
+
+    return fallback;
+}
+
+/* Put `o` on exactly the wallpaper `leader` is showing, and point o's cycle
+ * index at it, so the pair stays in step from here on.
+ *
+ * Only the leader ever steps a cycle; members are pushed its result. Their lists
+ * hold the same entries but need not hold them in the same ORDER (shuffle
+ * randomises each output's copy separately), so the leader's index means nothing
+ * here and the entry is located in o's own list by path. */
+static void output_adopt_group_wallpaper(struct output_state *o, struct output_state *leader) {
+    char entry[OUTPUT_MAX_PATH_LENGTH];
+    char live[OUTPUT_MAX_PATH_LENGTH];
+
+    pthread_mutex_lock(&o->state->state_mutex);
+    size_t index = leader->config->current_cycle_index;
+    if (leader->config->cycle_paths && index < leader->config->cycle_count) {
+        snprintf(entry, sizeof(entry), "%s", leader->config->cycle_paths[index]);
+    } else {
+        entry[0] = '\0';
+    }
+    snprintf(live, sizeof(live), "%s", output_live_path(leader));
+
+    if (entry[0] != '\0' && o->config->cycle_paths) {
+        o->config->current_cycle_index =
+            cycle_restore_index(o->config->cycle_paths, o->config->cycle_count, entry,
+                                o->config->current_cycle_index);
+    }
+    pthread_mutex_unlock(&o->state->state_mutex);
+
+    if (live[0] == '\0') {
+        return;
+    }
+
+    /* Remember the attempt before making it: if this shader compiles on the
+     * leader's GPU context but not on this one, we must not queue it again on
+     * every pass of the main loop. */
+    snprintf(o->span_synced_path, sizeof(o->span_synced_path), "%s", live);
+
+    if (o->config->type == WALLPAPER_SHADER) {
+        if (strcmp(output_live_path(o), live) != 0 &&
+            nw_is_err(output_set_shader(o, live))) {
+            log_error("Failed to sync output %s onto its span group's shader: %s",
+                      o->model[0] ? o->model : "unknown", live);
+            return;
+        }
+        /* Shader + image cycling: the shader is fixed and the cycle list feeds
+         * iChannel0, so the group is in step only once the image matches too. */
+        if (entry[0] != '\0' && strcmp(entry, live) != 0 &&
+            !render_update_channel_texture(o, 0, entry)) {
+            log_error("Failed to sync iChannel0 on output %s: %s",
+                      o->model[0] ? o->model : "unknown", entry);
+            return;
+        }
+    } else {
+        output_set_wallpaper(o, live);
+    }
+
+    atomic_store_explicit(&o->needs_redraw, true, memory_order_release);
+}
+
+void outputs_sync_span_group(struct output_state **outs, size_t count, size_t index) {
+    if (!outs || index >= count || !outs[index]) {
+        return;
+    }
+    struct output_state *me = outs[index];
+
+    /* The first member in list order leads; everyone else follows it. */
+    struct output_state *leader = NULL;
+    for (size_t i = 0; i < count; i++) {
+        if (outs[i] && output_same_span_group(me, outs[i])) {
+            leader = outs[i];
+            break;
+        }
+    }
+    if (!leader || leader == me) {
+        return;
+    }
+
+    const char *live = output_live_path(leader);
+    if (live[0] == '\0' || strcmp(output_live_path(me), live) == 0) {
+        return;
+    }
+    if (strcmp(me->span_synced_path, live) == 0) {
+        return;  /* already tried this one and it did not take */
+    }
+
+    log_info("Syncing output %s onto its span group's wallpaper: %s",
+             me->model[0] ? me->model : "unknown", live);
+    output_adopt_group_wallpaper(me, leader);
+}
+
+size_t output_cycle_group(struct output_state **outs, size_t count, struct output_state *leader) {
+    if (!leader) {
+        return 0;
+    }
+
+    /* Membership is settled BEFORE the leader moves: a shuffled wrap permutes
+     * the leader's list in place, and the members have not been given the new
+     * order yet, so asking again afterwards could fail to recognise them. */
+    struct output_state *members[MAX_OUTPUTS];
+    size_t n = 0;
+    for (size_t i = 0; i < count && n < MAX_OUTPUTS; i++) {
+        if (outs && outs[i] && outs[i] != leader && output_same_span_group(outs[i], leader)) {
+            members[n++] = outs[i];
+        }
+    }
+
+    output_cycle_wallpaper(leader);
+
+    for (size_t i = 0; i < n; i++) {
+        members[i]->span_synced_path[0] = '\0';
+        output_adopt_group_wallpaper(members[i], leader);
+        /* The group moved together, so its members' cycle timers must restart
+         * together too — otherwise each one fires again on its own schedule. */
+        members[i]->last_cycle_time = leader->last_cycle_time;
+    }
+
+    return n + 1;
+}
+
 /* Cycle to next wallpaper in the cycle list */
 void output_cycle_wallpaper(struct output_state *output) {
     if (!output) {

--- a/src/output/span.c
+++ b/src/output/span.c
@@ -1,0 +1,60 @@
+/* Pure virtual-screen geometry. See include/neowall/output/span.h. */
+#include "neowall/output/span.h"
+
+static bool rect_valid(const struct span_rect *r) {
+    return r->logical_w > 0 && r->logical_h > 0;
+}
+
+/* Device pixels per logical pixel. An output that has not heard a scale event
+ * yet carries 0; X11 always carries 1. Both mean "device == logical". */
+static int32_t rect_scale(const struct span_rect *r) {
+    return r->scale > 0 ? r->scale : 1;
+}
+
+bool span_compute(const struct span_rect *rects, size_t count, size_t index,
+                  struct span_view *out) {
+    if (!rects || !out || index >= count) {
+        return false;
+    }
+
+    const struct span_rect *me = &rects[index];
+    if (!rect_valid(me)) {
+        return false;
+    }
+
+    /* Logical, because that is the only space the outputs share: a device-pixel
+     * box over mixed scales is not a box over anything. See span.h. */
+    int32_t min_x = me->logical_x;
+    int32_t min_y = me->logical_y;
+    int32_t max_x = me->logical_x + me->logical_w;
+    int32_t max_y = me->logical_y + me->logical_h;
+
+    for (size_t i = 0; i < count; i++) {
+        const struct span_rect *r = &rects[i];
+        if (i == index || !rect_valid(r)) {
+            continue;
+        }
+        if (r->logical_x < min_x) min_x = r->logical_x;
+        if (r->logical_y < min_y) min_y = r->logical_y;
+        if (r->logical_x + r->logical_w > max_x) max_x = r->logical_x + r->logical_w;
+        if (r->logical_y + r->logical_h > max_y) max_y = r->logical_y + r->logical_h;
+    }
+
+    int32_t box_w = max_x - min_x;
+    int32_t box_h = max_y - min_y;
+    int32_t off_x = me->logical_x - min_x;
+    /* Flip: gl_FragCoord counts up from the window's bottom, span_rect's y counts
+     * down from the box's top. See span.h. */
+    int32_t off_y = box_h - ((me->logical_y - min_y) + me->logical_h);
+
+    /* Into MY framebuffer. Everything above is logical, everything below is
+     * device, and my scale is the only scale that may appear here: gl_FragCoord
+     * on this output knows no other. */
+    const int32_t s = rect_scale(me);
+    out->virt_w = box_w * s;
+    out->virt_h = box_h * s;
+    out->off_x = off_x * s;
+    out->off_y = off_y * s;
+    return true;
+}
+

--- a/src/render/render.c
+++ b/src/render/render.c
@@ -926,6 +926,17 @@ bool render_frame_shader(struct output_state *output) {
     int width = output->width;
     int height = output->height;
 
+    /* Hand the shader this output's slice of the scene its span group shares.
+     * Cleared to zero for an output that spans nothing, which is every
+     * single-monitor setup and leaves the sizing and uniforms below untouched. */
+    if (output->spanned) {
+        multipass_set_span(output->multipass_shader,
+                           output->span.virt_w, output->span.virt_h,
+                           output->span.off_x, output->span.off_y);
+    } else {
+        multipass_set_span(output->multipass_shader, 0, 0, 0, 0);
+    }
+
     /* Resize multipass buffers if needed */
     multipass_resize(output->multipass_shader, width, height);
 
@@ -933,9 +944,16 @@ bool render_frame_shader(struct output_state *output) {
      * stored in ms (shared with pause/resume bookkeeping); ms*1000 == µs on
      * the same monotonic epoch. Millisecond-quantized time visibly stutters:
      * at 60 FPS the 16.67ms interval alternates 16/17ms steps (~6% jitter). */
+    /* Spanned outputs run off the span group's shared start, not their own: two
+     * halves of one scene that started animating even a frame apart are visibly
+     * out of phase across the bezel. */
+    uint64_t epoch_ms = (output->spanned && output->span_start_time > 0)
+        ? output->span_start_time
+        : output->shader_start_time;
+
     uint64_t current_time_us = get_time_us();
-    uint64_t start_time_us = output->shader_start_time > 0
-        ? output->shader_start_time * 1000ull
+    uint64_t start_time_us = epoch_ms > 0
+        ? epoch_ms * 1000ull
         : current_time_us;
     /* Guard against start_time being (transiently) in the future — subtracting
      * unsigned would wrap to an enormous elapsed value. Can happen around a

--- a/src/shader/shader_multipass.c
+++ b/src/shader/shader_multipass.c
@@ -571,6 +571,9 @@ static const char *multipass_wrapper_prefix =
     "uniform float iTime;\n"
     "uniform vec3 iResolution;\n"
     "uniform vec4 iMouse;\n"
+    "// Shift from this window's gl_FragCoord to the virtual screen's. Zero\n"
+    "// unless the wallpaper is spanned across several monitors.\n"
+    "uniform vec2 iSpanOffset;\n"
     "uniform int iFrame;\n"
     "uniform float iTimeDelta;\n"
     "uniform float iFrameRate;\n"
@@ -605,7 +608,7 @@ static const char *multipass_wrapper_prefix =
 static const char *multipass_wrapper_suffix =
     "\n"
     "void main() {\n"
-    "    mainImage(fragColor, gl_FragCoord.xy);\n"
+    "    mainImage(fragColor, gl_FragCoord.xy + iSpanOffset);\n"
     "}\n";
 
 /**
@@ -1207,6 +1210,7 @@ static void cache_uniform_locations(multipass_pass_t *pass) {
     u->iFrameRate = glGetUniformLocation(prog, "iFrameRate");
     u->iFrame = glGetUniformLocation(prog, "iFrame");
     u->iResolution = glGetUniformLocation(prog, "iResolution");
+    u->iSpanOffset = glGetUniformLocation(prog, "iSpanOffset");
     u->iMouse = glGetUniformLocation(prog, "iMouse");
     u->iDate = glGetUniformLocation(prog, "iDate");
     u->iSampleRate = glGetUniformLocation(prog, "iSampleRate");
@@ -1444,12 +1448,32 @@ bool multipass_compile_all(multipass_shader_t *shader) {
     return all_success;
 }
 
+void multipass_set_span(multipass_shader_t *shader, int virt_width, int virt_height,
+                        int off_x, int off_y) {
+    if (!shader) return;
+
+    bool spans = virt_width > 0 && virt_height > 0;
+
+    shader->span_width = spans ? virt_width : 0;
+    shader->span_height = spans ? virt_height : 0;
+    shader->span_off_x = spans ? off_x : 0;
+    shader->span_off_y = spans ? off_y : 0;
+}
+
 void multipass_resize(multipass_shader_t *shader, int width, int height) {
     if (!shader || !shader->is_initialized) return;
 
+    /* Buffer passes are sized to the virtual screen when spanning, not to this
+     * window: they are sampled at fragCoord/iResolution.xy in virtual
+     * coordinates, so a window-sized buffer would be read off its own end. The
+     * Image pass keeps the window's size — it still only fills the window.
+     * Equal to width/height whenever the output is not spanned. */
+    int buffer_w = shader->span_width > 0 ? shader->span_width : width;
+    int buffer_h = shader->span_height > 0 ? shader->span_height : height;
+
     /* Calculate base scaled resolution (from adaptive resolution system) */
-    int base_scaled_w = (int)(width * shader->resolution_scale);
-    int base_scaled_h = (int)(height * shader->resolution_scale);
+    int base_scaled_w = (int)(buffer_w * shader->resolution_scale);
+    int base_scaled_h = (int)(buffer_h * shader->resolution_scale);
     if (base_scaled_w < 1) base_scaled_w = 1;
     if (base_scaled_h < 1) base_scaled_h = 1;
 
@@ -1576,11 +1600,26 @@ void multipass_set_uniforms(multipass_shader_t *shader,
     if (u->iFrameRate >= 0) glUniform1f(u->iFrameRate, shader->frame_fps);
     if (u->iFrame >= 0) glUniform1i(u->iFrame, shader->frame_count);
 
-    /* Resolution - changes per pass */
+    /* Resolution - changes per pass.
+     *
+     * When spanning, the Image pass fills only this monitor's window but must
+     * think in virtual-screen coordinates, so it reports the virtual size and
+     * shifts gl_FragCoord onto its slice. Buffer passes need neither: they are
+     * already sized to the virtual screen (multipass_resize), so pass->width IS
+     * the virtual width and their slice offset is zero. */
+    bool spanned = shader->span_width > 0 && shader->span_height > 0;
+    bool is_image = (pass->type == PASS_TYPE_IMAGE);
+
     if (u->iResolution >= 0) {
-        float w = (float)pass->width;
-        float h = (float)pass->height;
+        float w = (spanned && is_image) ? (float)shader->span_width : (float)pass->width;
+        float h = (spanned && is_image) ? (float)shader->span_height : (float)pass->height;
         glUniform3f(u->iResolution, w, h, w / h);
+    }
+
+    if (u->iSpanOffset >= 0) {
+        float ox = (spanned && is_image) ? (float)shader->span_off_x : 0.0f;
+        float oy = (spanned && is_image) ? (float)shader->span_off_y : 0.0f;
+        glUniform2f(u->iSpanOffset, ox, oy);
     }
 
     /* Mouse */

--- a/tests/test_span.c
+++ b/tests/test_span.c
@@ -1,0 +1,417 @@
+/* Unit tests for virtual-screen geometry (span.c).
+ *
+ * Spanning one shader across several monitors turns on two numbers per output:
+ * the size of the virtual screen (iResolution) and the offset added to
+ * gl_FragCoord. The offset's Y half is flipped, because gl_FragCoord counts up
+ * from the bottom while output positions count down from the top — a horizontal
+ * layout cannot catch that mistake (every off_y is 0 either way), so the stacked
+ * and mixed-height layouts below are the ones that matter.
+ *
+ * The other thing these numbers can get wrong is their UNIT. span_rect is
+ * logical, span_view is device, and every rect below carries the scale that
+ * converts between them. The scale-1 cases are the whole of X11 and the whole
+ * of any Wayland session that has not been told otherwise, so they are also the
+ * regression bar: at scale 1 the two spaces coincide and the expected values are
+ * plain pixels, exactly as they were before scale existed here.
+ */
+#include <stdbool.h>
+#include <stdio.h>
+
+#include "neowall/output/span.h"
+
+static int failures = 0;
+static int checks = 0;
+
+#define CHECK(cond)                                                            \
+    do {                                                                       \
+        checks++;                                                              \
+        if (!(cond)) {                                                         \
+            failures++;                                                        \
+            fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);    \
+        }                                                                      \
+    } while (0)
+
+#define CHECK_VIEW(v, w, h, ox, oy)                                            \
+    do {                                                                       \
+        CHECK((v).virt_w == (w));                                              \
+        CHECK((v).virt_h == (h));                                              \
+        CHECK((v).off_x == (ox));                                              \
+        CHECK((v).off_y == (oy));                                              \
+    } while (0)
+
+/* Every slice must sit wholly inside the virtual screen. Catches a sign error
+ * in either axis regardless of the layout — and, now that the two spaces are
+ * distinct, catches a slice measured in the wrong one: the rect is logical, the
+ * view is device, so the comparison only closes if the scale is applied. */
+static void check_contained(const struct span_rect *rects, size_t count) {
+    for (size_t i = 0; i < count; i++) {
+        struct span_view v;
+        if (!span_compute(rects, count, i, &v)) {
+            continue;
+        }
+        int32_t s = rects[i].scale > 0 ? rects[i].scale : 1;
+        CHECK(v.off_x >= 0);
+        CHECK(v.off_y >= 0);
+        CHECK(v.off_x + rects[i].logical_w * s <= v.virt_w);
+        CHECK(v.off_y + rects[i].logical_h * s <= v.virt_h);
+    }
+}
+
+/* A lone output must be untouched by spanning: the virtual screen is exactly it
+ * and both offsets are zero, so the shader sees precisely what it saw before. */
+static void test_single_monitor_is_identity(void) {
+    struct span_rect rects[] = {{0, 0, 2560, 1440, 1}};
+    struct span_view v;
+
+    CHECK(span_compute(rects, 1, 0, &v));
+    CHECK_VIEW(v, 2560, 1440, 0, 0);
+    check_contained(rects, 1);
+}
+
+/* Even parked away from the origin, one output alone spans only itself. */
+static void test_single_monitor_at_offset_is_identity(void) {
+    struct span_rect rects[] = {{100, 50, 1920, 1080, 1}};
+    struct span_view v;
+
+    CHECK(span_compute(rects, 1, 0, &v));
+    CHECK_VIEW(v, 1920, 1080, 0, 0);
+}
+
+static void test_horizontal_pair(void) {
+    struct span_rect rects[] = {
+        {0, 0, 2560, 1440, 1},
+        {2560, 0, 2560, 1440, 1},
+    };
+    struct span_view v;
+
+    CHECK(span_compute(rects, 2, 0, &v));
+    CHECK_VIEW(v, 5120, 1440, 0, 0);
+    CHECK(span_compute(rects, 2, 1, &v));
+    CHECK_VIEW(v, 5120, 1440, 2560, 0);
+    check_contained(rects, 2);
+}
+
+/* The flip's real test. rects[0] is the TOP monitor, so in gl_FragCoord's
+ * bottom-up space it is the one that must be pushed UP by a full screen height;
+ * the bottom monitor is the one that sits at zero. */
+static void test_vertical_pair_flips_y(void) {
+    struct span_rect rects[] = {
+        {0, 0, 2560, 1440, 1},     /* top */
+        {0, 1440, 2560, 1440, 1},  /* bottom */
+    };
+    struct span_view v;
+
+    CHECK(span_compute(rects, 2, 0, &v));
+    CHECK_VIEW(v, 2560, 2880, 0, 1440);
+    CHECK(span_compute(rects, 2, 1, &v));
+    CHECK_VIEW(v, 2560, 2880, 0, 0);
+    check_contained(rects, 2);
+}
+
+/* Top-aligned monitors of different heights: the shorter one's bottom edge is
+ * ABOVE the virtual bottom, so it gets a non-zero off_y. A naive `off_y =
+ * logical_y` would give it 0 and hang it off the wrong edge. */
+static void test_mixed_heights_top_aligned(void) {
+    struct span_rect rects[] = {
+        {0, 0, 2560, 1440, 1},
+        {2560, 0, 1920, 1080, 1},
+    };
+    struct span_view v;
+
+    CHECK(span_compute(rects, 2, 0, &v));
+    CHECK_VIEW(v, 4480, 1440, 0, 0);
+    CHECK(span_compute(rects, 2, 1, &v));
+    CHECK_VIEW(v, 4480, 1440, 2560, 360);
+    check_contained(rects, 2);
+}
+
+/* Bottom-aligned instead: now the short one sits at off_y 0 and the tall one
+ * still does too — but the box is the tall one's height. */
+static void test_mixed_heights_bottom_aligned(void) {
+    struct span_rect rects[] = {
+        {0, 0, 2560, 1440, 1},
+        {2560, 360, 1920, 1080, 1},
+    };
+    struct span_view v;
+
+    CHECK(span_compute(rects, 2, 0, &v));
+    CHECK_VIEW(v, 4480, 1440, 0, 0);
+    CHECK(span_compute(rects, 2, 1, &v));
+    CHECK_VIEW(v, 4480, 1440, 2560, 0);
+    check_contained(rects, 2);
+}
+
+/* X11 lets a monitor sit left of the origin. The box's origin moves with it and
+ * every offset stays non-negative, so the left monitor — not the one at x=0 —
+ * is the one that lands at off_x 0. */
+static void test_negative_x_offset(void) {
+    struct span_rect rects[] = {
+        {-2560, 0, 2560, 1440, 1},
+        {0, 0, 2560, 1440, 1},
+    };
+    struct span_view v;
+
+    CHECK(span_compute(rects, 2, 0, &v));
+    CHECK_VIEW(v, 5120, 1440, 0, 0);
+    CHECK(span_compute(rects, 2, 1, &v));
+    CHECK_VIEW(v, 5120, 1440, 2560, 0);
+    check_contained(rects, 2);
+}
+
+/* Same, stacked upward: the monitor above the origin is the one that gets the
+ * high off_y, and the origin monitor drops to 0. */
+static void test_negative_y_offset(void) {
+    struct span_rect rects[] = {
+        {0, -1440, 2560, 1440, 1},  /* above origin */
+        {0, 0, 2560, 1440, 1},
+    };
+    struct span_view v;
+
+    CHECK(span_compute(rects, 2, 0, &v));
+    CHECK_VIEW(v, 2560, 2880, 0, 1440);
+    CHECK(span_compute(rects, 2, 1, &v));
+    CHECK_VIEW(v, 2560, 2880, 0, 0);
+    check_contained(rects, 2);
+}
+
+/* An L-shape exercises both axes at once. */
+static void test_mixed_arrangement(void) {
+    struct span_rect rects[] = {
+        {0, 0, 1920, 1080, 1},
+        {1920, 0, 2560, 1440, 1},
+        {1920, 1440, 1280, 1024, 1},
+    };
+    struct span_view v;
+
+    /* Box: x 0..4480, y 0..2464 */
+    CHECK(span_compute(rects, 3, 0, &v));
+    CHECK_VIEW(v, 4480, 2464, 0, 2464 - 1080);
+    CHECK(span_compute(rects, 3, 1, &v));
+    CHECK_VIEW(v, 4480, 2464, 1920, 2464 - 1440);
+    CHECK(span_compute(rects, 3, 2, &v));
+    CHECK_VIEW(v, 4480, 2464, 1920, 0);
+    check_contained(rects, 3);
+}
+
+/* An output that has not been configured yet has no size. Letting it into the
+ * box would drag the origin to (0,0) and shift every real output's slice. */
+static void test_unsized_output_is_ignored(void) {
+    struct span_rect rects[] = {
+        {0, 0, 0, 0, 1},
+        {2560, 0, 2560, 1440, 1},
+        {5120, 0, 2560, 1440, 1},
+    };
+    struct span_view v;
+
+    CHECK(span_compute(rects, 3, 1, &v));
+    CHECK_VIEW(v, 5120, 1440, 0, 0);
+    CHECK(span_compute(rects, 3, 2, &v));
+    CHECK_VIEW(v, 5120, 1440, 2560, 0);
+
+    /* Nothing to compute for the unsized one itself. */
+    CHECK(!span_compute(rects, 3, 0, &v));
+}
+
+/* A HiDPI monitor beside a plain one. In the compositor's LOGICAL layout the two
+ * are the same size and sit side by side; in device pixels the left one is twice
+ * as wide as it is logically, and a box built out of device extents would have
+ * the right-hand monitor's rect (x=1920, w=1920) falling wholly INSIDE the left
+ * one's (x=0, w=3840) — the box would collapse to one monitor and the right-hand
+ * output would render a slice of a scene nobody was drawing.
+ *
+ * Both outputs draw the same 3840x1080 logical scene; each is handed it at its
+ * own density, so their iResolutions differ and neither is the sum of the two
+ * framebuffers. Derived by hand:
+ *   logical box:  x 0..1920 u 1920..3840 = 0..3840; y 0..1080 -> 3840x1080
+ *   A (scale 2):  virt 7680x2160; off_x (0-0)*2 = 0
+ *                 off_y (1080 - (0 + 1080)) * 2 = 0
+ *   B (scale 1):  virt 3840x1080; off_x (1920-0)*1 = 1920
+ *                 off_y (1080 - (0 + 1080)) * 1 = 0
+ * A's slice is uv.x 0..0.5 of the scene and B's is 0.5..1.0: continuous across
+ * the bezel, and the same logical distance per screen centimetre on both. */
+static void test_mixed_scale_hidpi_beside_sdr(void) {
+    struct span_rect rects[] = {
+        {0, 0, 1920, 1080, 2},     /* A: logical 1920x1080 @ (0,0), 3840x2160 device */
+        {1920, 0, 1920, 1080, 1},  /* B: logical 1920x1080 @ (1920,0), 1920x1080 device */
+    };
+    struct span_view v;
+
+    CHECK(span_compute(rects, 2, 0, &v));
+    CHECK_VIEW(v, 7680, 2160, 0, 0);
+    CHECK(span_compute(rects, 2, 1, &v));
+    CHECK_VIEW(v, 3840, 1080, 1920, 0);
+    check_contained(rects, 2);
+
+    /* Neither output's virtual screen is its own framebuffer, so neither trips
+     * the "group is just me" guard in outputs_update_spans() and drops out of
+     * the span. That guard firing for one of a pair is the visible symptom:
+     * one monitor renders the whole scene standalone while the other renders a
+     * slice of it. */
+    CHECK(span_compute(rects, 2, 0, &v));
+    CHECK(!(v.virt_w == 1920 * 2 && v.virt_h == 1080 * 2));
+    CHECK(span_compute(rects, 2, 1, &v));
+    CHECK(!(v.virt_w == 1920 && v.virt_h == 1080));
+}
+
+/* Mixed scales AND the Y flip at once: the flip is applied in logical space and
+ * scaled afterwards, so a bug that scales before flipping shows up here.
+ *   logical box:  x 0..1920 u 0..2560 = 0..2560
+ *                 y 0..1080 u 1080..2520 = 0..2520  -> 2560x2520
+ *   top (scale 2):  virt 5120x5040; off_x 0
+ *                   off_y (2520 - (0 + 1080)) * 2 = 1440 * 2 = 2880
+ *   bottom (sc 1):  virt 2560x2520; off_x 0
+ *                   off_y (2520 - (1080 + 1440)) * 1 = 0 */
+static void test_mixed_scale_stacked_flips_y_in_logical_space(void) {
+    struct span_rect rects[] = {
+        {0, 0, 1920, 1080, 2},     /* top:    logical 1920x1080, 3840x2160 device */
+        {0, 1080, 2560, 1440, 1},  /* bottom: logical 2560x1440, 2560x1440 device */
+    };
+    struct span_view v;
+
+    CHECK(span_compute(rects, 2, 0, &v));
+    CHECK_VIEW(v, 5120, 5040, 0, 2880);
+    CHECK(span_compute(rects, 2, 1, &v));
+    CHECK_VIEW(v, 2560, 2520, 0, 0);
+    check_contained(rects, 2);
+}
+
+/* Uniform scale factors straight out of the answer: a pair of scale-2 monitors
+ * gives exactly what the same pair at scale 1 gives, times two, in both axes and
+ * both offsets. This is the sanity check on the whole scheme — where all outputs
+ * agree on a scale, logical and device differ only by that constant. */
+static void test_uniform_scale_is_a_constant_factor(void) {
+    struct span_rect one[] = {
+        {0, 0, 2560, 1440, 1},
+        {2560, 0, 2560, 1440, 1},
+    };
+    struct span_rect two[] = {
+        {0, 0, 2560, 1440, 2},
+        {2560, 0, 2560, 1440, 2},
+    };
+    struct span_view a, b;
+
+    for (size_t i = 0; i < 2; i++) {
+        CHECK(span_compute(one, 2, i, &a));
+        CHECK(span_compute(two, 2, i, &b));
+        CHECK(b.virt_w == a.virt_w * 2);
+        CHECK(b.virt_h == a.virt_h * 2);
+        CHECK(b.off_x == a.off_x * 2);
+        CHECK(b.off_y == a.off_y * 2);
+    }
+    check_contained(two, 2);
+}
+
+/* THE REGRESSION BAR. At scale 1 logical and device are the same space, so every
+ * view must be plain pixels — bit for bit what span_compute returned before it
+ * knew what a scale was. An output that has not yet heard a scale event carries
+ * 0, which must read as 1 rather than collapsing the scene to nothing. */
+static void test_scale_one_and_unset_are_the_pixel_identity(void) {
+    struct span_rect ones[] = {
+        {0, 0, 2560, 1440, 1},
+        {2560, 0, 1920, 1080, 1},
+    };
+    struct span_rect unset[] = {
+        {0, 0, 2560, 1440, 0},
+        {2560, 0, 1920, 1080, 0},
+    };
+    struct span_view v;
+
+    /* Identical to test_mixed_heights_top_aligned, in device pixels. */
+    CHECK(span_compute(ones, 2, 0, &v));
+    CHECK_VIEW(v, 4480, 1440, 0, 0);
+    CHECK(span_compute(ones, 2, 1, &v));
+    CHECK_VIEW(v, 4480, 1440, 2560, 360);
+
+    CHECK(span_compute(unset, 2, 0, &v));
+    CHECK_VIEW(v, 4480, 1440, 0, 0);
+    CHECK(span_compute(unset, 2, 1, &v));
+    CHECK_VIEW(v, 4480, 1440, 2560, 360);
+    check_contained(unset, 2);
+}
+
+/* `xrandr --same-as` with UNEQUAL resolutions: two outputs on one origin, the
+ * smaller nested inside the larger. X shows the smaller one the top-left crop of
+ * the region, and that is exactly what the box arithmetic hands it.
+ *   box: x 0..1920, y 0..1080 (the union) -> 1920x1080
+ *   big:   virt 1920x1080; off_x 0; off_y 1080 - (0 + 1080) = 0
+ *          -> its own size at zero offset, i.e. the whole scene. The caller's
+ *             degenerate guard short-circuits this to standalone, which draws
+ *             the identical picture.
+ *   small: virt 1920x1080; off_x 0; off_y 1080 - (0 + 720) = 360
+ *          -> rows 360..1080 counting up from the bottom = the TOP 720 rows, and
+ *             columns 0..1280 = the LEFT 1280. The top-left crop. */
+static void test_nested_clone_gets_the_matching_crop(void) {
+    struct span_rect rects[] = {
+        {0, 0, 1920, 1080, 1},  /* big */
+        {0, 0, 1280, 720, 1},   /* clone of it, smaller mode, same origin */
+    };
+    struct span_view v;
+
+    CHECK(span_compute(rects, 2, 0, &v));
+    CHECK_VIEW(v, 1920, 1080, 0, 0);
+    CHECK(span_compute(rects, 2, 1, &v));
+    CHECK_VIEW(v, 1920, 1080, 0, 360);
+    check_contained(rects, 2);
+}
+
+/* And the clone pair must not poison the rest of the group. A third, ordinary
+ * tiled output beside the cloned pair goes on spanning exactly as it would have
+ * without them — a nested rect widens no box and moves no origin.
+ *   box: x 0..1920 u 0..1280 u 1920..3840 = 0..3840; y 0..1080 -> 3840x1080
+ *   big:   off_x 0;    off_y 1080 - 1080 = 0     (now 3840 wide != its own 1920:
+ *                                                 spans, rather than degenerate)
+ *   small: off_x 0;    off_y 1080 - 720  = 360
+ *   tiled: off_x 1920; off_y 1080 - 1080 = 0 */
+static void test_nested_clone_does_not_disable_the_group(void) {
+    struct span_rect rects[] = {
+        {0, 0, 1920, 1080, 1},     /* big */
+        {0, 0, 1280, 720, 1},      /* its clone */
+        {1920, 0, 1920, 1080, 1},  /* an ordinary tiled monitor beside them */
+    };
+    struct span_view v;
+
+    CHECK(span_compute(rects, 3, 0, &v));
+    CHECK_VIEW(v, 3840, 1080, 0, 0);
+    CHECK(span_compute(rects, 3, 1, &v));
+    CHECK_VIEW(v, 3840, 1080, 0, 360);
+    CHECK(span_compute(rects, 3, 2, &v));
+    CHECK_VIEW(v, 3840, 1080, 1920, 0);
+    check_contained(rects, 3);
+}
+
+static void test_rejects_bad_input(void) {
+    struct span_rect rects[] = {{0, 0, 2560, 1440, 1}};
+    struct span_view v;
+
+    CHECK(!span_compute(NULL, 1, 0, &v));
+    CHECK(!span_compute(rects, 1, 0, NULL));
+    CHECK(!span_compute(rects, 1, 1, &v));
+    CHECK(!span_compute(rects, 0, 0, &v));
+}
+
+int main(void) {
+    test_single_monitor_is_identity();
+    test_single_monitor_at_offset_is_identity();
+    test_horizontal_pair();
+    test_vertical_pair_flips_y();
+    test_mixed_heights_top_aligned();
+    test_mixed_heights_bottom_aligned();
+    test_negative_x_offset();
+    test_negative_y_offset();
+    test_mixed_arrangement();
+    test_unsized_output_is_ignored();
+    test_mixed_scale_hidpi_beside_sdr();
+    test_mixed_scale_stacked_flips_y_in_logical_space();
+    test_uniform_scale_is_a_constant_factor();
+    test_scale_one_and_unset_are_the_pixel_identity();
+    test_nested_clone_gets_the_matching_crop();
+    test_nested_clone_does_not_disable_the_group();
+    test_rejects_bad_input();
+
+    if (failures == 0) {
+        printf("ok - %d checks passed\n", checks);
+        return 0;
+    }
+    fprintf(stderr, "not ok - %d/%d checks failed\n", failures, checks);
+    return 1;
+}


### PR DESCRIPTION
A dual-head desktop currently shows the **same scene twice**, once per monitor, rather than one scene across both. Each monitor gets its own window with `iResolution` set to that monitor's size, so a shader drawing a single continuous image draws two independent copies of it.

This PR keeps the per-monitor windows and gives each one its slice. The Image pass reports the bounding box of the monitor group as `iResolution` and offsets `fragCoord` by the window's position within it, so the heads draw adjacent parts of one image. Per-output config, per-output occlusion and hotplug all keep working, which a single X11 window spanning the virtual screen could not do, and which has no Wayland equivalent since layer-shell surfaces are per-output by construction.

Outputs whose cycle list matches form a span group: the leader steps the cycle and pushes the result, members locate the entry by path in their own list, and drifted outputs converge. `iTime` runs off the group's earliest start time so both halves animate on one clock; without it the seam shows a phase break rather than a picture.

## Coordinate spaces

The box is computed in **logical** coordinates and converted to device pixels once, per output, at that output's own scale.

This is load-bearing, because the two quantities the box is built from do not share a space. `x_offset`/`y_offset` come from `zxdg_output_v1::logical_position`, defined by the protocol as a position "within the global compositor space", and the xdg-output XML's own example fixes that space's unit:

> for a wl_output mode 3840×2160 and a scale factor 2 … will advertise a logical size of 1920×1080

Meanwhile `output->width`/`height` are device pixels (`logical * scale`). A logical origin packed with a device extent gives a box that is wrong whenever `scale != 1`: on two 3840×2160 outputs at scale 2 the rects **overlap instead of tiling**, the bounding box collapses to one monitor's size, and one output drops out of the span entirely while its sibling renders a slice of a virtual screen that does not exist.

So `span_rect` carries `logical_x/y/w/h` plus the output's `scale`, named for the space they are in, and `outputs_update_spans()` does the conversion at the single seam where it belongs. `iResolution` therefore differs between heads of different density: each renders the same logical scene at its own pixel density, which is what makes the seam line up. Device-pixel concatenation would not, since two monitors the same physical size on the desk would draw the scene at different sizes and clip half of it.

**On X11 `scale` is always 1**, so this is a division by one and every value is unchanged.

## Verification

`meson test`: 11/11 (297 checks in `test_span`). Clean under the project's `-Werror`.

`tests/test_span.c` covers the offset arithmetic (stacked, mixed-height top- and bottom-aligned, negative origins, three-monitor L-shape), the mixed-scale box, mixed-scale stacked (which catches scaling before flipping), and the nested clone that `xrandr --same-as` at mismatched resolutions produces.

A differential harness compiled the previous `span_compute()` alongside the new one and compared every output over **5,001,577 randomised layouts**: identical in all of them at scale 1, clean under ASan and UBSan. Not in the tree.

End to end on X11, Muffin, two 2560×1440 heads side by side, logging the uniforms actually uploaded for the Image pass rather than inferring them from pixels:

```
iResolution=(5120,1440)  offset=(0,0)     window=2560x1440   <- head at +0+0
iResolution=(5120,1440)  offset=(2560,0)  window=2560x1440   <- head at +2560+0
```

Identical before and after the logical-space change, as it must be at scale 1. That instrumentation is not part of this change.

## Known limits

The Wayland `scale != 1` path is **not exercised end to end**: there is no Wayland session on this machine. Its evidence is the unit tests and the protocol text quoted above, not a running compositor.

Fractional scaling is out of scope. `scale` is an integer here; a fractional-scale compositor will need the pixel geometry rather than `logical * scale`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
